### PR TITLE
Initial dict_list function

### DIFF
--- a/docs/src/project.md
+++ b/docs/src/project.md
@@ -89,7 +89,7 @@ BSON.bson(datadir()*"sims/test.bson", file)
 ```
 
 ## Reproducibility
-This project setup approach that DrWatson suggests has a very big side-benefit: it is fully reproducible firstly because it uses Julia's suggested project structure and secondly because the navigation only uses local directories.
+This project setup approach that DrWatson suggests has a very big side-benefit: it is fully reproducible firstly because it uses Julia's suggested project structure, secondly because the navigation only uses local directories and lastly because it is a Git repository.
 
 If you send your entire project folder to a colleague, they only need to do:
 ```julia
@@ -98,3 +98,5 @@ pkg> activate .
 pkg> instantiate
 ```
 All required packages and dependencies will be installed and then any script that was running in your computer will also be running in their computer **in the same way!**
+
+In addition, with DrWatson you have the possibility of "tagging" each simulation created with the commit id, see the discussion around [`current_commit`](@ref) and [`tag!`](@ref).

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -4,7 +4,7 @@ import Pkg, LibGit2
 
 include("project_setup.jl")
 include("naming.jl")
-include("saving.jl")
+include("saving_tools.jl")
 
 # Functionality that requires Optional Packages:
 using Requires

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -22,13 +22,12 @@ values of the dictionary while the non-`Vector` values are kept constant
 for all possibilities. The keys of the entries are the same.
 
 ## Examples
-julia> d = Dict(:a => [1, 2, 3], :b => 4);
+julia> d = Dict(:a => [1, 2], :b => 4);
 
 julia> dict_list(d)
 3-element Array{Dict{Symbol,Int64},1}:
  Dict(:a=>1,:b=>4)
  Dict(:a=>2,:b=>4)
- Dict(:a=>3,:b=>4)
 
 julia> d[:c] = "test"; d[:d] = ["lala", "lulu"];
 
@@ -36,21 +35,21 @@ julia> dict_list(d)
 6-element Array{Dict{Symbol,Any},1}:
  Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lala",:c=>"test")
- Dict(:a=>3,:b=>4,:d=>"lala",:c=>"test")
  Dict(:a=>1,:b=>4,:d=>"lulu",:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lulu",:c=>"test")
- Dict(:a=>3,:b=>4,:d=>"lulu",:c=>"test")
 
-julia> d[:e] = [[0.1, 0.2]]; # final result retains the inner vector
+julia> d[:e] = [[0.1, 0.2], [0.1, 0.3]];
 
 julia> dict_list(d)
-6-element Array{Dict{Symbol,Any},1}:
+8-element Array{Dict{Symbol,Any},1}:
  Dict(:a=>1,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>3,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
  Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>3,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lala",:e=>[0.1, 0.3],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:e=>[0.1, 0.3],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[0.1, 0.3],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[0.1, 0.3],:c=>"test")
 """
 function dict_list(d)
     vec(map(Iterators.product(values(d)...)) do vals

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -13,3 +13,70 @@ function current_commit(path = projectdir())
     repo = LibGit2.GitRepo(path)
     return string(LibGit2.head_oid(repo))
 end
+
+"""
+    dict_list(d)
+Take the dictionary `d` and expand it into a vector of dictionaries.
+Each entry has a unique combination from the product of the `Vector`
+values of the dictionary while the non-`Vector` values are kept constant
+for all possibilities. The keys of the entries are the same.
+
+## Examples
+julia> d = Dict(:a => [1, 2, 3], :b => 4);
+
+julia> dict_list(d)
+3-element Array{Dict{Symbol,Int64},1}:
+ Dict(:a=>1,:b=>4)
+ Dict(:a=>2,:b=>4)
+ Dict(:a=>3,:b=>4)
+
+julia> d[:c] = "test"; d[:d] = ["lala", "lulu"];
+
+julia> dict_list(d)
+6-element Array{Dict{Symbol,Any},1}:
+ Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:c=>"test")
+ Dict(:a=>3,:b=>4,:d=>"lala",:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:c=>"test")
+ Dict(:a=>3,:b=>4,:d=>"lulu",:c=>"test")
+
+julia> d[:e] = [[0.1, 0.2]]; # final result retains the inner vector
+
+julia> dict_list(d)
+6-element Array{Dict{Symbol,Any},1}:
+ Dict(:a=>1,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>3,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
+ Dict(:a=>3,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
+"""
+function dict_list(d)
+    vec(map(Iterators.product(values(d)...)) do vals
+        Dict(keys(d) .=> vals)
+    end)
+end
+
+# function namedtuple_list(d::NamedTuple)
+#     vec(map(Iterators.product(values(d)...)) do vals
+#         s = tuple(keys(d)...)
+#         NamedTuple{s,typeof(vals)}(vals)
+#     end)
+# end
+
+
+# function prepare(cs...)
+#     allkeys = [allaccess(c) for c in cs]
+#
+#     if !allunique(Iterators.flatten(allkeys))
+#         error("The keys of the given containers are not all unique.")
+#     end
+#
+#     # Key type of the final dictionary:
+#     K = promote_type([eltype(k) for k in allkeys]...)
+#     total = Dict{K, Any}()
+#     for (i, acc) in enumerate(allkeys)
+#         c = cs[i]
+#         for k in acc
+#             if eltype(c[k]) <: Vector # Expand

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -1,3 +1,6 @@
+export current_commit
+export dict_list, ntuple_list
+
 function addrun! end
 
 function current_commit(path = projectdir())
@@ -16,10 +19,13 @@ end
 
 """
     dict_list(d)
-Take the dictionary `d` and expand it into a vector of dictionaries.
+Expand the dictionary `d` into a vector of dictionaries.
 Each entry has a unique combination from the product of the `Vector`
 values of the dictionary while the non-`Vector` values are kept constant
 for all possibilities. The keys of the entries are the same.
+
+Whether the values of `d` are iterable or not is of no concern;
+the function considers as "iterable" only subtypes of `Vector`.
 
 ## Examples
 julia> d = Dict(:a => [1, 2], :b => 4);
@@ -32,29 +38,38 @@ julia> dict_list(d)
 julia> d[:c] = "test"; d[:d] = ["lala", "lulu"];
 
 julia> dict_list(d)
-6-element Array{Dict{Symbol,Any},1}:
+4-element Array{Dict{Symbol,Any},1}:
  Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lala",:c=>"test")
  Dict(:a=>1,:b=>4,:d=>"lulu",:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lulu",:c=>"test")
 
-julia> d[:e] = [[0.1, 0.2], [0.1, 0.3]];
+julia> d[:e] = [[1, 2], [3, 5]];
 
 julia> dict_list(d)
 8-element Array{Dict{Symbol,Any},1}:
- Dict(:a=>1,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>2,:b=>4,:d=>"lala",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[0.1, 0.2],:c=>"test")
- Dict(:a=>1,:b=>4,:d=>"lala",:e=>[0.1, 0.3],:c=>"test")
- Dict(:a=>2,:b=>4,:d=>"lala",:e=>[0.1, 0.3],:c=>"test")
- Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[0.1, 0.3],:c=>"test")
- Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[0.1, 0.3],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lala",:e=>[1, 2],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:e=>[1, 2],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[1, 2],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[1, 2],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lala",:e=>[3, 5],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:e=>[3, 5],:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
 """
 function dict_list(d)
-    vec(map(Iterators.product(values(d)...)) do vals
-        Dict(keys(d) .=> vals)
-    end)
+    iterable_fields = filter(k -> typeof(d[k]) <: Vector, keys(d))
+    non_iterables = setdiff(keys(d), iterable_fields)
+
+    iterable_dict = Dict(iterable_fields .=> getindex.(Ref(d), iterable_fields))
+    non_iterable_dict = Dict(non_iterables .=> getindex.(Ref(d), non_iterables))
+
+    vec(
+        map(Iterators.product(values(iterable_dict)...)) do vals
+            dd = Dict(keys(iterable_dict) .=> vals)
+            merge(non_iterable_dict, dd)
+        end
+    )
 end
 
 # function namedtuple_list(d::NamedTuple)

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -1,4 +1,4 @@
-export current_commit, tag!
+export current_commit, tag
 export dict_list, ntuple_list
 
 function addrun! end
@@ -27,7 +27,7 @@ function current_commit(path = projectdir())
 end
 
 """
-    tag!(d::Dict, path = projectdir()) -> d
+    tag(d::Dict, path = projectdir()) -> d
 Tag `d` by adding an extra field `commit` which will have as value
 the [`current_commit`](@ref) of the repository at `path` (by default
 the project's path).
@@ -43,14 +43,14 @@ Dict{Symbol,Int64} with 2 entries:
   :y => 4
   :x => 3
 
-julia> tag!(d)
+julia> tag(d)
 Dict{Symbol,Any} with 3 entries:
   :y      => 4
   :commit => "96df587e45b29e7a46348a3d780db1f85f41de04"
   :x      => 3
 ```
 """
-function tag!(d::Dict{K, T}, path = projectdir()) where {K, T}
+function tag(d::Dict{K, T}, path = projectdir()) where {K, T}
     c = current_commit(path)
     c === nothing && return d
     if haskey(d, K("commit"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ using DrWatson, Test
 
 @testset "Naming" begin include("naming_tests.jl"); end
 @testset "Project Setup" begin include("project_tests.jl"); end
+@testset "Saving tools" begin include("stools_tests.jl"); end
 @testset "Produce or Save" begin include("savefiles_tests.jl"); end

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -43,3 +43,13 @@ v3 = dict_list(c)
 for el in c3
     @test el ∈ v3
 end
+
+# tag!
+d1 = Dict(:x => 3, :y => 4)
+d2 = Dict("x" => 3, "y" => 4)
+for d in (d1, d2)
+    d = tag(d)
+
+    @test haskey(d, keytype(d)(:commit))
+    @test d[ keytype(d)(:commit)] |> typeof == String
+end

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -1,0 +1,35 @@
+using DrWatson, Test
+
+# Test commit function
+com = current_commit(dirname(@__DIR__))
+@test com !== nothing
+@test typeof(com) == String
+
+# Test dictionary expansion
+c = Dict(:a => [1, 2], :b => 4);
+c1 = [ Dict(:a=>1,:b=>4)
+ Dict(:a=>2,:b=>4)]
+
+@test dict_list(c) == c1
+
+c[:c] = "test"; c[:d] = ["lala", "lulu"];
+c2 = [ Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lala",:c=>"test")
+ Dict(:a=>1,:b=>4,:d=>"lulu",:c=>"test")
+ Dict(:a=>2,:b=>4,:d=>"lulu",:c=>"test")]
+
+@test dict_list(c) == c2
+
+c[:e] = [[1, 2], [3, 5]];
+c3 = [
+Dict(:a=>1,:b=>4,:d=>"lala",:e=>[1, 2],:c=>"test")
+Dict(:a=>2,:b=>4,:d=>"lala",:e=>[1, 2],:c=>"test")
+Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[1, 2],:c=>"test")
+Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[1, 2],:c=>"test")
+Dict(:a=>1,:b=>4,:d=>"lala",:e=>[3, 5],:c=>"test")
+Dict(:a=>2,:b=>4,:d=>"lala",:e=>[3, 5],:c=>"test")
+Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
+Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
+]
+
+@test dict_list(c) == c3

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -10,7 +10,10 @@ c = Dict(:a => [1, 2], :b => 4);
 c1 = [ Dict(:a=>1,:b=>4)
  Dict(:a=>2,:b=>4)]
 
-@test dict_list(c) == c1
+v1 = dict_list(c)
+for el in c1
+    @test el ∈ v1
+end
 
 c[:c] = "test"; c[:d] = ["lala", "lulu"];
 c2 = [ Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
@@ -18,7 +21,11 @@ c2 = [ Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
  Dict(:a=>1,:b=>4,:d=>"lulu",:c=>"test")
  Dict(:a=>2,:b=>4,:d=>"lulu",:c=>"test")]
 
-@test dict_list(c) == c2
+v2 = dict_list(c)
+for el in c2
+    @test el ∈ v2
+end
+
 
 c[:e] = [[1, 2], [3, 5]];
 c3 = [
@@ -32,4 +39,7 @@ Dict(:a=>1,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
 Dict(:a=>2,:b=>4,:d=>"lulu",:e=>[3, 5],:c=>"test")
 ]
 
-@test dict_list(c) == c3
+v3 = dict_list(c)
+for el in c3
+    @test el ∈ v3
+end

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -48,8 +48,8 @@ end
 d1 = Dict(:x => 3, :y => 4)
 d2 = Dict("x" => 3, "y" => 4)
 for d in (d1, d2)
-    d = tag(d)
+    d = tag(d, dirname(@__DIR__))
 
     @test haskey(d, keytype(d)(:commit))
-    @test d[ keytype(d)(:commit)] |> typeof == String
+    @test d[keytype(d)(:commit)] |> typeof == String
 end


### PR DESCRIPTION
Currently this function "fails" because for example if a key of the dictionary `d` is a string then the function expands over it and makes the entries `Char`:

```
julia> d = Dict(:a => [1, 2, 3], :b => 4, :c => "test")
Dict{Symbol,Any} with 3 entries:
  :a => [1, 2, 3]
  :b => 4
  :c => "test"

julia> dict_list(d)
12-element Array{Dict{Symbol,Any},1}:
 Dict(:a=>1,:b=>4,:c=>'t')
 Dict(:a=>2,:b=>4,:c=>'t')
 Dict(:a=>3,:b=>4,:c=>'t')
 Dict(:a=>1,:b=>4,:c=>'e')
 Dict(:a=>2,:b=>4,:c=>'e')
 Dict(:a=>3,:b=>4,:c=>'e')
 Dict(:a=>1,:b=>4,:c=>'s')
 Dict(:a=>2,:b=>4,:c=>'s')
 Dict(:a=>3,:b=>4,:c=>'s')
 Dict(:a=>1,:b=>4,:c=>'t')
 Dict(:a=>2,:b=>4,:c=>'t')
 Dict(:a=>3,:b=>4,:c=>'t')
```

In general it is difficult to predict whether any arbitrary used-defined type should be iterable or not in this case. However establishing the rule that only top level `Vector` types are expanded would make this general and intuitive at the same time.

The problem is, I don't know how to do it. Any help appreciated.