### PR TITLE
Add macros @tag and @tagsave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+# 0.2.0
+* Changed `path` and `projectpath` arguments of various functions (e.g. `tagsave`, `current_commit`) to `gitpath` universally.
 # 0.1.0
 This is the first beta release! Changelog is kept with respect to here!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 0.2.0
 * Changed `path` and `projectpath` arguments of various functions (e.g. `tagsave`, `current_commit`) to `gitpath` universally.
+* make keyword arguments of `tagsave` positional arguments instead (to work with the macros)
+* Added two new macros: `@tag!` and `@tagsave`: these do the same thing as `tag!, tagsave` but in addition are able to record both the script name that called them as well as the line of code that they were called at.
+
 # 0.1.0
 This is the first beta release! Changelog is kept with respect to here!

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -12,7 +12,7 @@ The macros [`@dict`](@ref) and [`@strdict`](@ref) can help with that.
 
 ## Keywords
 * `tag = true` : Add the Git commit of the project in the saved file.
-* `projectpath = projectdir()` : Path to search for a Git repo.
+* `gitpath = projectdir()` : Path to search for a Git repo.
 * `suffix = "bson"` : Used in `savename`.
 * `force = false` : If `true` then don't check if file `s` exists and produce
   it and save it anyway.
@@ -22,7 +22,7 @@ See also [`savename`](@ref) and [`tag!`](@ref).
 """
 produce_or_load(c, f; kwargs...) = produce_or_load("", c, f; kwargs...)
 function produce_or_load(prefix::String, c, f;
-    tag::Bool = true, projectpath = projectdir(),
+    tag::Bool = true, gitpath = projectdir(),
     suffix = "bson", force = false, kwargs...)
 
     s = savename(prefix, c, suffix; kwargs...)
@@ -40,7 +40,7 @@ function produce_or_load(prefix::String, c, f;
         try
             mkpath(dirname(s))
             if tag
-                tagsave(s, file; projectpath = projectpath)
+                tagsave(s, file; gitpath = gitpath)
             else
             wsave(s, copy(file))
         end
@@ -53,15 +53,15 @@ function produce_or_load(prefix::String, c, f;
 end
 
 """
-    tagsave(file::String, d::Dict; projectpath, safe)
+    tagsave(file::String, d::Dict; gitpath, safe)
 First [`tag!`](@ref) dictionary `d` and then save `d` in `file`.
 
 ## Keywords
-* `projectpath = projectdir()` : Path of the Git repository.
+* `gitpath = projectdir()` : Path of the Git repository.
 * `safe = false` : Save the file using [`safesave`](@ref).
 """
-function tagsave(file, d; projectpath = projectdir(), safe = false)
-    d2 = tag!(d, projectpath)
+function tagsave(file, d; gitpath = projectdir(), safe = false)
+    d2 = tag!(d, gitpath)
     if safe
         safesave(file, copy(d2))
     else

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -1,4 +1,4 @@
-export current_commit, tag!
+export current_commit, tag!, @tag!
 export dict_list, dict_list_count
 
 """
@@ -71,8 +71,8 @@ function tag!(d::Dict{K, T}, gitpath = projectdir(), source = nothing) where {K,
     c = current_commit(gitpath)
     c === nothing && return d
     if haskey(d, K("commit"))
-        @warn "The dictionary already has a key named `commit`. We won't "
-        "overwrite it with the commit id."
+        @warn "The dictionary already has a key named `commit`. We won't "*
+        "add any Git information."
         return d
     end
     if String <: T
@@ -83,7 +83,7 @@ function tag!(d::Dict{K, T}, gitpath = projectdir(), source = nothing) where {K,
     end
     if source != nothing
         if haskey(d, K("script"))
-            @warn "The dictionary already has a key named `script`. We won't "
+            @warn "The dictionary already has a key named `script`. We won't "*
             "overwrite it with the script name."
         else
             d[K("script")] = relative_to_project(source, gitpath)
@@ -101,13 +101,11 @@ end
 sourcename(s) = string(s)
 sourcename(s::LineNumberNode) = string(s.file)*"#"*string(s.line)
 
-export @tag!
-
 """
     @tag!(d, gitpath = projectdir()) -> d
-Do the same as [`tag`](@ref) but also add another field `script` that has
-the gitpath of the script that called `@tag!`, relative with respect to `gitpath`.
-The gitpath ends with `#line_number`, which indicates the line number within the
+Do the same as [`tag!`](@ref) but also add another field `script` that has
+the path of the script that called `@tag!`, relative with respect to `gitpath`.
+The path ends with `#line_number`, which indicates the line number within the
 script that `@tag!` was called at.
 
 ## Examples
@@ -121,7 +119,6 @@ Dict{Symbol,Any} with 3 entries:
   :script => "test\\stools_tests.jl#10"
   :x      => 3
 ```
-
 """
 macro tag!(d, gitpath = projectdir())
     s = QuoteNode(__source__)

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -86,16 +86,10 @@ function tag!(d::Dict{K, T}, gitpath = projectdir(), source = nothing) where {K,
             @warn "The dictionary already has a key named `script`. We won't "*
             "overwrite it with the script name."
         else
-            d[K("script")] = relative_to_project(source, gitpath)
+            d[K("script")] = relpath(sourcename(source), gitpath)
         end
     end
     return d
-end
-
-function relative_to_project(s, gitpath)
-    s = sourcename(s)
-    f = setdiff!(splitpath(s), splitpath(gitpath))
-    return joinpath(f...)
 end
 
 sourcename(s) = string(s)
@@ -105,8 +99,8 @@ sourcename(s::LineNumberNode) = string(s.file)*"#"*string(s.line)
     @tag!(d, gitpath = projectdir()) -> d
 Do the same as [`tag!`](@ref) but also add another field `script` that has
 the path of the script that called `@tag!`, relative with respect to `gitpath`.
-The path ends with `#line_number`, which indicates the line number within the
-script that `@tag!` was called at.
+The saved string ends with `#line_number`, which indicates the line number
+within the script that `@tag!` was called at.
 
 ## Examples
 ```julia

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -1,5 +1,5 @@
 using DrWatson, Test
-
+cd(@__DIR__)
 T = 1000
 N = 50 # spatial extent
 Δt = 0.05 # resolution of integration
@@ -14,6 +14,36 @@ function f(simulation)
     return @strdict a b simulation
 end
 
+
+################################################################################
+#                                 tagsave                                      #
+################################################################################
+t = f(simulation)
+tagsave(savename(simulation, "bson"), t, findproject())
+file = load(savename(simulation, "bson"))
+@test "commit" ∈ keys(file)
+@test file["commit"] |> typeof == String
+rm(savename(simulation, "bson"))
+
+t = f(simulation)
+@tagsave(savename(simulation, "bson"), t, false, findproject())
+file = load(savename(simulation, "bson"))
+@test "commit" ∈ keys(file)
+@test file["commit"] |> typeof == String
+@test "script" ∈ keys(file)
+@test file["script"] |> typeof == String
+
+t = f(simulation)
+@tagsave(savename(simulation, "bson"), t, true, findproject())
+sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
+@test isfile(sn)
+rm(savename(simulation, "bson"))
+rm(sn)
+@test !isfile(savename(simulation, "bson"))
+
+################################################################################
+#                              produce or load                                 #
+################################################################################
 for ending ∈ ("bson", "jld2")
     @test !isfile(savename(simulation, "bson"))
     sim = produce_or_load(simulation, f; suffix = ending)
@@ -24,7 +54,6 @@ for ending ∈ ("bson", "jld2")
     rm(savename(simulation, ending))
     @test !isfile(savename(simulation, ending))
 end
-
 
 ################################################################################
 #                          Backup files before saving                          #

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -32,6 +32,7 @@ file = load(savename(simulation, "bson"))
 @test file["commit"] |> typeof == String
 @test "script" ∈ keys(file)
 @test file["script"] |> typeof == String
+@test file["script"] == joinpath("test", "savefiles_tests.jl#29")
 
 t = f(simulation)
 @tagsave(savename(simulation, "bson"), t, true, findproject())

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -1,9 +1,32 @@
 using DrWatson, Test
 
 # Test commit function
+com = current_commit(@__DIR__)
+@test com === nothing
+
 com = current_commit(dirname(@__DIR__))
 @test com !== nothing
 @test typeof(com) == String
+
+# tag!
+d1 = Dict(:x => 3, :y => 4)
+d2 = Dict("x" => 3, "y" => 4)
+for d in (d1, d2)
+    d = tag!(d, dirname(@__DIR__))
+
+    @test haskey(d, keytype(d)(:commit))
+    @test d[keytype(d)(:commit)] |> typeof == String
+end
+
+# @tag!
+for d in (d1, d2)
+    d = @tag!(d, @__DIR__)
+    @test !haskey(d, keytype(d)(:commit))
+
+    d = @tag!(d, dirname(@__DIR__))
+    @test d[keytype(d)(:commit)] |> typeof == String
+    @test d[keytype(d)(:script)][1:4] == "test"
+end
 
 # Test dictionary expansion
 c = Dict(:a => [1, 2], :b => 4);
@@ -43,14 +66,4 @@ v3 = dict_list(c)
 @test dict_list_count(c) == length(c3) == length(v3)
 for el in c3
     @test el ∈ v3
-end
-
-# tag!
-d1 = Dict(:x => 3, :y => 4)
-d2 = Dict("x" => 3, "y" => 4)
-for d in (d1, d2)
-    d = tag!(d, dirname(@__DIR__))
-
-    @test haskey(d, keytype(d)(:commit))
-    @test d[keytype(d)(:commit)] |> typeof == String
 end


### PR DESCRIPTION
Closes #35
These macros are able to record the source file that called them, as well as the line of code they were called at. As a result, they do the same as `tag!, tagsave` but record additional reproducibility information.