### PR TITLE
Improve typing on return type of `dict_list`

### DIFF
--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -174,7 +174,13 @@ function dict_list(c::Dict)
     vec(
         map(Iterators.product(values(iterable_dict)...)) do vals
             dd = Dict(keys(iterable_dict) .=> vals)
-            merge(non_iterable_dict, dd)
+            if isempty(non_iterable_dict)
+                dd
+            elseif isempty(iterable_dict)
+                non_iterable_dict
+            else
+                merge(non_iterable_dict, dd)
+            end
         end
     )
 end

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -37,6 +37,7 @@ v1 = dict_list(c)
 for el in c1
     @test el ∈ v1
 end
+@test keytype(eltype(v1)) == Symbol
 
 c[:c] = "test"; c[:d] = ["lala", "lulu"];
 c2 = [ Dict(:a=>1,:b=>4,:d=>"lala",:c=>"test")
@@ -48,7 +49,7 @@ v2 = dict_list(c)
 for el in c2
     @test el ∈ v2
 end
-
+@test keytype(eltype(v2)) == Symbol
 
 c[:e] = [[1, 2], [3, 5]];
 c3 = [
@@ -67,3 +68,13 @@ v3 = dict_list(c)
 for el in c3
     @test el ∈ v3
 end
+@test keytype(eltype(v3)) == Symbol
+
+v4 = dict_list(Dict(:a => 1, :b => 2.0)) # both non-iterable
+@test keytype(eltype(v4)) == Symbol
+
+v5 = dict_list(Dict(:a => [1], :b => 2.0)) # one non-iterable
+@test keytype(eltype(v5)) == Symbol
+
+v6 = dict_list(Dict(:a => [1], :b => [2.0])) # both iterable
+@test keytype(eltype(v6)) == Symbol


### PR DESCRIPTION
I came across the following minor incovenience:
```julia
julia> d = Dict(:x => [1], :y => [2.0])
Dict{Symbol,Array{T,1} where T} with 2 entries:
  :y => [2.0]
  :x => [1]

julia> dict_list(d)
1-element Array{Dict{Any,Any},1}:
 Dict(:y=>2.0,:x=>1)
```
The return type of `dict_list` is a `Vector` of `Dict{Any,Any}`, when the type of the key (at least) should be able to be inferred. It turns out that it is due to merging the `iterable_dict` with the `non_iterable_dict` inside the `dict_list` method, where `non_iterable_dict` is an empty `Dict{Any,Any}`.

The fix is simply to check for emptiness, and only merging if they are both non-empty. Then, we get the expected output:
```julia
julia> dict_list(d)
1-element Array{Dict{Symbol,Real},1}:
 Dict(:y=>2.0,:x=>1)
```
I've added some corresponding tests, too.