### PR TITLE
Expand functionality for savename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.4.0
+* Add expand functionality to `savename`, which handles better containers with nested containers (#50)
 * `produce_or_load` now allows the possibility of not loading the file
 * New function `struct2dict` that converts a struct to a dictionary (for saving)
 # 0.3.0

--- a/docs/src/name.md
+++ b/docs/src/name.md
@@ -9,22 +9,22 @@ This is what the function [`savename`](@ref) does. Of course, you don't have to 
 
 ```@docs
 savename
-@dict
-@strdict
-@ntuple
 ```
 
 Notice that this naming scheme integrates perfectly with Parameters.jl.
 
-Two convenience functions are also provided to easily switch between named tuples and dictionaries:
+## Convenience functions
+Convenience functions are provided to easily create named tuples, dictionaries as well as switch between them:
 ```@docs
+@dict
+@strdict
+@ntuple
 ntuple2dict
 dict2ntuple
 ```
 
 ## Customizing `savename`
-You can customize [`savename`](@ref) for your own Types. For example you could make it so that it only uses some specific keys instead of all of them, only specific types, or you could make it access data in a different way (maybe even loading files!). You can even make it have
-a custom `prefix`!
+You can customize [`savename`](@ref) for your own Types. For example you could make it so that it only uses some specific keys instead of all of them, only specific types, or you could make it access data in a different way (maybe even loading files!). You can even make it have a custom `prefix`!
 
 To do that you may extend the following functions:
 ```@docs
@@ -32,6 +32,8 @@ DrWatson.allaccess
 DrWatson.access
 DrWatson.default_allowed
 DrWatson.default_prefix
+DrWatson.default_expand
 ```
 
 See [Real World Examples](@ref) for an example of customizing `savename`.
+Specifically, have a look at [`savename` and nested containers](@ref) for a way to

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -2,54 +2,6 @@ export savename, @dict, @ntuple, @strdict
 export ntuple2dict, dict2ntuple
 
 """
-    allaccess(c)
-Return all the keys `c` can be accessed using [`access`](@ref).
-For dictionaries/named tuples this is `keys(c)`,
-for everything else it is `fieldnames(typeof(c))`.
-"""
-allaccess(c::AbstractDict) = collect(keys(c))
-allaccess(c::NamedTuple) = keys(c)
-allaccess(c::Any) = fieldnames(typeof(c))
-allaccess(c::DataType) = fieldnames(c)
-allaccess(c::String) = error("`c` must be a container, not a string!")
-
-"""
-    access(c, key)
-Access `c` with given key. For `AbstractDict` this is `getindex`,
-for anything else it is `getproperty`.
-
-    access(c, keys...)
-When given multiple keys, `access` is called recursively, i.e.
-`access(c, key1, key2) = access(access(c, key1), key2)` and so on.
-For example, if `c, c.k1` are `NamedTuple`s then
-`access(c, k1, k2) == c.k1.k2`.
-
-!!! note
-    Please only extend the single key method when customizing `access`
-    for your own Types.
-"""
-access(c, keys...) = access(access(c, keys[1]), Base.tail(keys)...)
-access(c::AbstractDict, key) = getindex(c, key)
-access(c, key) = getproperty(c, key)
-
-"""
-    default_allowed(c) = (Real, String, Symbol)
-Return the (super-)Types that will be used as `allowedtypes`
-in [`savename`](@ref) or other similar functions.
-"""
-default_allowed(c) = (Real, String, Symbol)
-
-"""
-    default_prefix(c) = ""
-Return the `prefix` that will be used by default
-in [`savename`](@ref) or other similar functions.
-"""
-default_prefix(c) = ""
-
-
-default_expand(c) = String[]
-
-"""
     savename([prefix,], c [, suffix]; kwargs...)
 Create a shorthand name, commonly used for saving a file, based on the
 parameters in the container `c` (`Dict`, `NamedTuple` or any other Julia
@@ -141,6 +93,59 @@ function savename(prefix::String, c, suffix::String;
     suffix != "" && (s *= "."*suffix)
     return s
 end
+
+"""
+    allaccess(c)
+Return all the keys `c` can be accessed using [`access`](@ref).
+For dictionaries/named tuples this is `keys(c)`,
+for everything else it is `fieldnames(typeof(c))`.
+"""
+allaccess(c::AbstractDict) = collect(keys(c))
+allaccess(c::NamedTuple) = keys(c)
+allaccess(c::Any) = fieldnames(typeof(c))
+allaccess(c::DataType) = fieldnames(c)
+allaccess(c::String) = error("`c` must be a container, not a string!")
+
+"""
+    access(c, key)
+Access `c` with given key. For `AbstractDict` this is `getindex`,
+for anything else it is `getproperty`.
+
+    access(c, keys...)
+When given multiple keys, `access` is called recursively, i.e.
+`access(c, key1, key2) = access(access(c, key1), key2)` and so on.
+For example, if `c, c.k1` are `NamedTuple`s then
+`access(c, k1, k2) == c.k1.k2`.
+
+!!! note
+    Please only extend the single key method when customizing `access`
+    for your own Types.
+"""
+access(c, keys...) = access(access(c, keys[1]), Base.tail(keys)...)
+access(c::AbstractDict, key) = getindex(c, key)
+access(c, key) = getproperty(c, key)
+
+"""
+    default_allowed(c) = (Real, String, Symbol)
+Return the (super-)Types that will be used as `allowedtypes`
+in [`savename`](@ref) or other similar functions.
+"""
+default_allowed(c) = (Real, String, Symbol)
+
+"""
+    default_prefix(c) = ""
+Return the `prefix` that will be used by default
+in [`savename`](@ref) or other similar functions.
+"""
+default_prefix(c) = ""
+
+"""
+    default_expand(c) = String[]
+Keys that should be expanded in their `savename` within [`savename`](@ref).
+Must be `Vector{String}` (as all keys are first translated into strings inside
+`savename`).
+"""
+default_expand(c) = String[]
 
 """
     @dict vars...

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -45,4 +45,15 @@ d = 5; e = @dict c d
 @test DrWatson.access(e, :c, :a) == a
 ff = dict2ntuple(e)
 @test DrWatson.access(ff, :c, :a) == a
-@test ff.c.a == a 
+@test ff.c.a == a
+
+# Expand tests:
+a = 3; b = 4
+c = @dict a b
+d = 5; e = @dict c d
+
+s = savename(e; allowedtypes = (Any,), expand = ["c"])
+@test '(' ∈ s
+@test ')' ∈ s
+@test occursin("a=3", s)
+@test occursin("b=4", s)


### PR DESCRIPTION
This PR allows `savename` to be used a bit more flexibly with structs that contain containers within them. 

(see docs)