### PR TITLE
new return value for produce_or_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.5.0
 This release has **breaking changes**.
-* Adjusted return value of `produce_or_load`. It now always return the file and the path it is saved. If `loadfile = false` it returns `nothing, path`.
+* Adjusted return value of `produce_or_load` (#52). It now always return the file and the path it is saved. If `loadfile = false` it returns `nothing, path`.
 * The functionality of `default_prefix` has been modified (#51). Now there is a nice interplay between defining a `default_prefix` *and* passing a prefix to `savename`. They are merged like `joinpath(prefix, default_prefix)`. This is valid only when `default_prefix` has a value other than `""` (the default).
 # 0.4.0
 * Add expand functionality to `savename`, which handles better containers with nested containers (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 0.5.0
+This release has **breaking changes**.
+* Adjusted return value of `produce_or_load`. It now always return the file and the path it is saved. If `loadfile = false` it returns `nothing, path`.
 * The functionality of `default_prefix` has been modified (#51). Now there is a nice interplay between defining a `default_prefix` *and* passing a prefix to `savename`. They are merged like `joinpath(prefix, default_prefix)`. This is valid only when `default_prefix` has a value other than `""` (the default).
 # 0.4.0
 * Add expand functionality to `savename`, which handles better containers with nested containers (#50)

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -1,12 +1,13 @@
 export produce_or_load, tagsave, @tagsave, safesave
 
 """
-    produce_or_load([prefix="",] c, f; kwargs...) -> file
+    produce_or_load([prefix="",] c, f; kwargs...) -> file, path
 Let `s = savename(prefix, c, suffix)`.
-If a file named `s` exists then load it and return it (default behavior).
+If a file named `s` exists then load it and return it, along
+with the path that it is saved at, `s` (default behavior).
 
 If the file does not exist then call `file = f(c)`, save `file` as
-`s` and then return the `file`.
+`s` and then return `file, s`.
 The function `f` must return a dictionary.
 The macros [`@dict`](@ref) and [`@strdict`](@ref) can help with that.
 
@@ -18,7 +19,7 @@ The macros [`@dict`](@ref) and [`@strdict`](@ref) can help with that.
   it and save it anyway.
 * `loadfile = true` : If `false`, this function does not actually load the
   file, but only checks if it exists. The return value in this case is always
-  `nothing`, regardless of whether the file must be produced or not.
+  `nothing, s`, regardless of whether the file must be produced or not.
 * `verbose = true` : print info about the process.
 * `kwargs...` : All other keywords are propagated to `savename`.
 
@@ -34,9 +35,9 @@ function produce_or_load(prefix::String, c, f;
     if !force && isfile(s)
         if loadfile
             file = wload(s)
-            return file
+            return file, s
         else
-            return nothing
+            return nothing, s
         end
     else
         if force
@@ -57,9 +58,9 @@ function produce_or_load(prefix::String, c, f;
             "\nReturning the file if `loadfile=true`."
         end
         if loadfile
-            return file
+            return file, s
         else
-            return nothing
+            return nothing, s
         end
     end
 end

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -46,16 +46,17 @@ rm(sn)
 #                              produce or load                                 #
 ################################################################################
 for ending ∈ ("bson", "jld2")
-    @test !isfile(savename(simulation, "bson"))
-    sim = produce_or_load(simulation, f; suffix = ending)
+    @test !isfile(savename(simulation, ending))
+    sim, path = produce_or_load(simulation, f; suffix = ending)
     @test isfile(savename(simulation, ending))
     @test sim["simulation"].T == T
-    sim = produce_or_load(simulation, f; suffix = ending)
+    @test path == savename(simulation, ending)
+    sim, path = produce_or_load(simulation, f; suffix = ending)
     @test sim["simulation"].T == T
     rm(savename(simulation, ending))
     @test !isfile(savename(simulation, ending))
 end
-@test produce_or_load(simulation, f; loadfile = false) == nothing
+@test produce_or_load(simulation, f; loadfile = false)[1] == nothing
 rm(savename(simulation, "bson"))
 @test !isfile(savename(simulation, "bson"))
 


### PR DESCRIPTION
It is really convenient to immediately access the path a filed is saved at with produce_or_load. This change takes care of that.

Heavily breaking, but what can you do. This is the life. I am a bit unhappy about the return value, which can be a file or `nothing`, but I think it is advantageous to not always have to load very large files...