### PR TITLE
Add function for reverse engineering savename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 docs/data
 Manifest.toml
 test/testdir
+src/update*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.6.0
 * **[BREAKING]** Reworked the way the functions `projectdir` and derivatives work (#47, #64, #66). Now `projectdir(args...)` uses `joinpath` to connect arguments. None of the functions like `projectdir` and derivatives now end in `/` as well, to ensure more stability and motivate users to use `joinpath` or the new functionality of `projectdir(args...)` instead of using string multiplication `*`.
+* New function `parse_savename` that attempts to reverse engineer the result of `savename`.
+
 # 0.5.1
 * Improvements to `.gitignore` (#55 , #54)
 # 0.5.0

--- a/docs/src/name.md
+++ b/docs/src/name.md
@@ -38,3 +38,8 @@ DrWatson.default_expand
 
 See [Real World Examples](@ref) for an example of customizing `savename`.
 Specifically, have a look at [`savename` and nested containers](@ref) for a way to
+
+## Reverse-engineering `savename`
+```@docs
+parse_savename
+```

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -43,6 +43,8 @@ This will likely break usage of e.g. `datadir` that used `*`, like it was
 suggested in the old (unhealthy) documentation. We are very sorry
 for this inconvenience!
 
+[NEW] New funtion `parse_savename` that reverse-engineers the output
+of `savename`!
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -270,8 +270,7 @@ function parse_savename(filename::AbstractString;
     # Prefix can be anything, so it might also contain a folder which's
     # name was generated using savename. Therefore first the path is split
     # into folders and filename.
-    savename_split = splitpath(filename)
-    prefix_part, savename_part = savename_split[1:end-1],savename_split[end]
+    prefix_part, savename_part = dirname(filename),basename(filename)
     # Extract the suffix. A suffix is identified by searching for the last "."
     # after the last "=".
     last_eq = findlast("=",savename_part)
@@ -301,6 +300,8 @@ function parse_savename(filename::AbstractString;
         # Of course the connector symbol could also be part of the variable name.
         prefix, _parameters = name[1:first(first_connector)-1], name[first(first_connector)+1:end]
     end
+    # Add leading directory back to prefix
+    prefix = joinpath(prefix_part,prefix)
     parameters = Dict{String,Any}()
     # Regex that matches smalles possible range between $connector and =.
     # This way it is possible to corretly match something like

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -26,6 +26,7 @@ See [`default_prefix`](@ref) for more.
 
 `savename` can be very conveniently combined with
 [`@dict`](@ref) or [`@ntuple`](@ref).
+See also [`parse_savename`](@ref).
 
 ## Keywords
 * `allowedtypes = default_allowed(c)` : Only values of type subtyping
@@ -254,12 +255,13 @@ end
 
 """
     parse_savename(filename::AbstractString; kwargs...)
-Try to convert a shorthand name produced with [`savename`](@ref) into a dictionary 
-containing the parameters, a prefix and suffix string.
+Try to convert a shorthand name produced with [`savename`](@ref) into a dictionary
+containing the parameters and their values, a prefix and suffix string.
+Return `prefix, parameters, suffix`.
 
-Parsing the key-value parts of `fielname` is performed under the assumption that the value
+Parsing the key-value parts of `filename` is performed under the assumption that the value
 is delimited by `=` and the closest `connector`. This allows the user to have `connector`
-(eg. '_') in a key name (variable name) but not in the value part.
+(eg. `_`) in a key name (variable name) but not in the value part.
 
 ## Keywords
 * `connector = "_"` : string used to connect the various entries.
@@ -269,7 +271,10 @@ is delimited by `=` and the closest `connector`. This allows the user to have `c
 function parse_savename(filename::AbstractString;
                         parsetypes = (Int, Float64),
                         connector::AbstractString = "_")
-    @assert length(connector) == 1 "Cannot parse savenames where the 'connector' string consists of more than one character."
+    length(connector) == 1 || error(
+    "Cannot parse savenames where the 'connector'"*
+    " string consists of more than one character.")
+
     # Prefix can be anything, so it might also contain a folder which's
     # name was generated using savename. Therefore first the path is split
     # into folders and filename.

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -254,8 +254,6 @@ end
 
 """
     parse_savename(filename::AbstractString; kwargs...)
-                        parsetypes = (Int, Float64),
-                        connector = "_")
 Try to convert a shorthand name produced with [`savename`](@ref) into a dictionary 
 containing the parameters, a prefix and suffix string.
 

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -268,7 +268,8 @@ is delimited by `=` and the closest `connector`. This allows the user to have `c
 """
 function parse_savename(filename::AbstractString;
                         parsetypes = (Int, Float64),
-                        connector = "_")
+                        connector::AbstractString = "_")
+    @assert length(connector) == 1 "Cannot parse savenames where the 'connector' string consists of more than one character."
     # Prefix can be anything, so it might also contain a folder which's
     # name was generated using savename. Therefore first the path is split
     # into folders and filename.

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -275,7 +275,7 @@ function parse_savename(filename::AbstractString;
     # after the last "=".
     last_eq = findlast("=",savename_part)
     last_dot = findlast(".",savename_part)
-    if isnothing(last_dot) || last_eq > last_dot
+    if last_dot == nothing || last_eq > last_dot
         # if no dot is after the last "="
         # there is no suffix
         name, suffix = savename_part,""
@@ -293,7 +293,7 @@ function parse_savename(filename::AbstractString;
     # an "=".
     first_eq = findfirst("=",name)
     first_connector = findfirst(connector,name)
-    if isnothing(first_connector) || first(first_eq) < first(first_connector)
+    if first_connector == nothing || first(first_eq) < first(first_connector)
         prefix, _parameters = "", name
     else
         # There is a connector symbol before, so there might be a connector.
@@ -332,7 +332,7 @@ Fallback is `String` ie. `str` is returned.
 function parse_from_savename_value(types::NTuple{N,<:Type},str::AbstractString) where N
     for t in types
         res = tryparse(t,str)
-        isnothing(res) || return res
+        res == nothing || return res
     end
     return str
 end

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -57,3 +57,75 @@ s = savename(e; allowedtypes = (Any,), expand = ["c"])
 @test ')' ∈ s
 @test occursin("a=3", s)
 @test occursin("b=4", s)
+
+# Tests for parse_savename
+
+function test_convert(prefix::AbstractString,c;kwargs...)
+    name = savename(prefix,c;kwargs...)
+    prefix, _b, suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && prefix == prefix && suffix == ""
+end
+
+function test_convert(c,suffix::AbstractString;kwargs...)
+    name = savename(c,suffix;kwargs...)
+    prefix, _b, suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && suffix == suffix && prefix == ""
+end
+
+function test_convert(prefix::AbstractString,c,suffix::AbstractString;kwargs...)
+    name = savename(prefix,c,suffix;kwargs...)
+    prefix, _b, suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && suffix == suffix && prefix == prefix
+end
+
+function test_convert(c;kwargs...)
+    name = savename(c;kwargs...)
+    prefix, _b, suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && prefix == ""
+end
+
+function dicts_equal(a,b)
+    kA,kB = keys(a), keys(b)
+    kA != kB && return false
+    for k ∈ kA
+        a[k] != b[k] && return false
+    end
+    return true
+end
+
+
+@test test_convert(
+    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+    digits=4)
+
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+                   digits=4)
+
+@test test_convert(
+    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+    "suffix",
+    digits=4)
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+                   "suffix",
+                   digits=4)
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble"),
+                   "suffix",
+                   digits=4)
+@test test_convert("a=10_mode=double/prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble"),
+                   "suffix",
+                   digits=4)
+@test test_convert(Dict("c" => 0.1534, "u" => 5.1),
+                   digits=4)
+@test test_convert(Dict("never" => "gonna", "give" => "you", "up" => "!"))
+@test test_convert(Dict("c" => 0.1534),
+                   digits=4)
+
+b = Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble")
+name = savename("prefix",b,connector="-",digits=4)
+prefix, _b, suffix = DrWatson.parse_savename(name,connector="-")
+@test dicts_equal(_b,b) && prefix == "prefix" && suffix == ""
+

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -133,3 +133,5 @@ _prefix, _b, _suffix = DrWatson.parse_savename("some_random_path_a=10.0/prefix_a
 @test _b["a"] == 10.0
 @test _b["just_a_string"] == "I'm not allowed to use underscores here"
 @test _b["my_value"] == 10.1
+
+@test_throws AssertionError DrWatson.parse_savename("a=10",connector="__")

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -109,11 +109,11 @@ end
                    "suffix",
                    digits=4)
 @test test_convert("prefix",
-                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble"),
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
                    "suffix",
                    digits=4)
 @test test_convert("a=10_mode=double/prefix",
-                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble"),
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
                    "suffix",
                    digits=4)
 @test test_convert(Dict("c" => 0.1534, "u" => 5.1),
@@ -122,8 +122,14 @@ end
 @test test_convert(Dict("c" => 0.1534),
                    digits=4)
 
-b = Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble")
-name = savename("prefix",b,connector="-",digits=4)
-_prefix, _b, _suffix = DrWatson.parse_savename(name,connector="-")
+b = Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mo_de" => "double")
+name = savename("prefix",b,connector="_",digits=4)
+_prefix, _b, _suffix = DrWatson.parse_savename(name,connector="_")
 @test dicts_equal(_b,b) && _prefix == "prefix" && _suffix == ""
 
+_prefix, _b, _suffix = DrWatson.parse_savename("some_random_path_a=10.0/prefix_a=10_just_a_string=I'm not allowed to use underscores here_my_value=10.1.suffix_with_underscore-but-don't-use-dots")
+@test _prefix == "some_random_path_a=10.0/prefix" 
+@test _suffix == "suffix_with_underscore-but-don't-use-dots"
+@test _b["a"] == 10.0
+@test _b["just_a_string"] == "I'm not allowed to use underscores here"
+@test _b["my_value"] == 10.1

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -62,26 +62,26 @@ s = savename(e; allowedtypes = (Any,), expand = ["c"])
 
 function test_convert(prefix::AbstractString,c;kwargs...)
     name = savename(prefix,c;kwargs...)
-    prefix, _b, suffix = DrWatson.parse_savename(name)
-    dicts_equal(_b,c) && prefix == prefix && suffix == ""
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _prefix == prefix && _suffix == ""
 end
 
 function test_convert(c,suffix::AbstractString;kwargs...)
     name = savename(c,suffix;kwargs...)
-    prefix, _b, suffix = DrWatson.parse_savename(name)
-    dicts_equal(_b,c) && suffix == suffix && prefix == ""
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _suffix == suffix && _prefix == ""
 end
 
 function test_convert(prefix::AbstractString,c,suffix::AbstractString;kwargs...)
     name = savename(prefix,c,suffix;kwargs...)
-    prefix, _b, suffix = DrWatson.parse_savename(name)
-    dicts_equal(_b,c) && suffix == suffix && prefix == prefix
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _suffix == suffix && _prefix == prefix
 end
 
 function test_convert(c;kwargs...)
     name = savename(c;kwargs...)
-    prefix, _b, suffix = DrWatson.parse_savename(name)
-    dicts_equal(_b,c) && prefix == ""
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _prefix == "" && _suffix == ""
 end
 
 function dicts_equal(a,b)
@@ -97,11 +97,9 @@ end
 @test test_convert(
     Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
     digits=4)
-
 @test test_convert("prefix",
                    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
                    digits=4)
-
 @test test_convert(
     Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
     "suffix",
@@ -126,6 +124,6 @@ end
 
 b = Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "dou_ble")
 name = savename("prefix",b,connector="-",digits=4)
-prefix, _b, suffix = DrWatson.parse_savename(name,connector="-")
-@test dicts_equal(_b,b) && prefix == "prefix" && suffix == ""
+_prefix, _b, _suffix = DrWatson.parse_savename(name,connector="-")
+@test dicts_equal(_b,b) && _prefix == "prefix" && _suffix == ""
 

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -113,7 +113,7 @@ end
                    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
                    "suffix",
                    digits=4)
-@test test_convert("a=10_mode=double/prefix",
+@test test_convert(joinpath("a=10_mode=double","prefix"),
                    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
                    "suffix",
                    digits=4)
@@ -128,8 +128,8 @@ name = savename("prefix",b,connector="_",digits=4)
 _prefix, _b, _suffix = DrWatson.parse_savename(name,connector="_")
 @test dicts_equal(_b,b) && _prefix == "prefix" && _suffix == ""
 
-_prefix, _b, _suffix = DrWatson.parse_savename("some_random_path_a=10.0/prefix_a=10_just_a_string=I'm not allowed to use underscores here_my_value=10.1.suffix_with_underscore-but-don't-use-dots")
-@test _prefix == "some_random_path_a=10.0/prefix" 
+_prefix, _b, _suffix = DrWatson.parse_savename(joinpath("some_random_path_a=10.0","prefix")*"_a=10_just_a_string=I'm not allowed to use underscores here_my_value=10.1.suffix_with_underscore-but-don't-use-dots")
+@test _prefix == joinpath("some_random_path_a=10.0","prefix")
 @test _suffix == "suffix_with_underscore-but-don't-use-dots"
 @test _b["a"] == 10.0
 @test _b["just_a_string"] == "I'm not allowed to use underscores here"

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -135,4 +135,4 @@ _prefix, _b, _suffix = DrWatson.parse_savename(joinpath("some_random_path_a=10.0
 @test _b["just_a_string"] == "I'm not allowed to use underscores here"
 @test _b["my_value"] == 10.1
 
-@test_throws AssertionError DrWatson.parse_savename("a=10",connector="__")
+@test_throws ErrorException DrWatson.parse_savename("a=10",connector="__")


### PR DESCRIPTION
Implements a function to parse the savename into a dict and extract the pre- and suffix (#38).
I thought of some special cases
- prefix is a path containing a folder named something like "a=1.23_mode=double"
- key or value contains `connector` (no precise solution, I'm adding them to the value part)
- last number is a float so the "." doesn't denote the start of the suffix
