### PR TITLE
Use git describe if possible for tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/data
 Manifest.toml
 test/testdir
 src/update*
+test project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* **[DEPRECATED]** `current_commit()` has been deprecated and replaced by
+  `gitdescribe()` which now replaces the output of `git describe` if an
+  annotated tag exists, otherwise it will return the latest commit hash.
+
 # 0.6.0
 * **[BREAKING]** Reworked the way the functions `projectdir` and derivatives work (#47, #64, #66). Now `projectdir(args...)` uses `joinpath` to connect arguments. None of the functions like `projectdir` and derivatives now end in `/` as well, to ensure more stability and motivate users to use `joinpath` or the new functionality of `projectdir(args...)` instead of using string multiplication `*`.
 * New function `parse_savename` that attempts to reverse engineer the result of `savename`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.7.0
 * New macro `@savename` that is a shortcut for `savename(@dict vars...)`
-* New function `gitdiscribe` (see below)
+* New function `gitdescribe` (see below)
 * **[DEPRECATED]** `current_commit()` has been deprecated and replaced by
   `gitdescribe()` which now replaces the output of `git describe` if an
   annotated tag exists, otherwise it will return the latest commit hash.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/docs/src/save.md
+++ b/docs/src/save.md
@@ -31,7 +31,7 @@ For reproducibility reasons (and also to not go insane when asking "HOW DID I GE
 To this end we have some functions that can be used to ensure reproducibility:
 
 ```@docs
-current_commit
+gitdescribe
 tag!
 @tag!
 ```

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -27,7 +27,7 @@ end
 
 # Update messages
 display_update = true
-update_version = "0.6.0"
+update_version = "0.7.0"
 update_name = "update_v$update_version"
 if display_update
 if !isfile(joinpath(@__DIR__, update_name))
@@ -35,16 +35,11 @@ printstyled(stdout,
 """
 \nUpdate message: DrWatson v$update_version
 
-[BREAKING] The function `projectdir` as well
-as its derivatives like `datadir` have changed their internals to use
-`joinpath` and in general promote the healthier usage of `joinpath`.
-This means that their return value no longer end in "\"!.
-This will likely break usage of e.g. `datadir` that used `*`, like it was
-suggested in the old (unhealthy) documentation. We are very sorry
-for this inconvenience!
+New function `@savename`, `current_commit` deprecated for `gitdescribe`
+(with improved functionality)
 
-[NEW] New funtion `parse_savename` that reverse-engineers the output
-of `savename`!
+Do not forget the BREAKING change regarding `projectdir` that occured
+in v0.6.0!
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -12,9 +12,19 @@ with `"_dirty"`.
 
 Return `nothing` if `gitpath` is not a Git repository.
 
-See also [`tag!`](@ref).
+The format of the `git describe` output in general is
+
+    `"TAGNAME-[NUMBER_OF_COMMITS_AHEAD-]gLATEST_COMMIT_HASH[_dirty]"`
+
+If the latest tag is `v1.2.3` and there are 5 additional commits while the
+latest commit hash is 334a0f225d9fba86161ab4c8892d4f023688159c, the output
+will be `v1.2.3-5-g334a0f`. Notice that git will shorten the hash if there
+are no ambiguous commits.
+
 More information about the `git describe` output can be found on 
 (https://git-scm.com/docs/git-describe)
+
+See also [`tag!`](@ref).
 
 ## Examples
 ```julia

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -41,13 +41,12 @@ function current_commit(gitpath = projectdir())
     # then we return the output of `git describe` or the latest commit hash
     # if no annotated tags are available
     repo = LibGit2.GitRepo(gitpath)
-    c = begin try
-            gdr = LibGit2.GitDescribeResult(repo)
-            fopt = LibGit2.DescribeFormatOptions(dirty_suffix=pointer(suffix))
-            LibGit2.format(gdr, options=fopt)
-        catch GitError
-            string(LibGit2.head_oid(repo)) * suffix
-        end
+    c = try
+        gdr = LibGit2.GitDescribeResult(repo)
+        fopt = LibGit2.DescribeFormatOptions(dirty_suffix=pointer(suffix))
+        LibGit2.format(gdr, options=fopt)
+    catch GitError
+        string(LibGit2.head_oid(repo)) * suffix
     end
     return c
 end

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -29,7 +29,7 @@ function current_commit(gitpath = projectdir())
     try
         repo = LibGit2.GitRepo(gitpath)
     catch er
-        @warn "The directory ('$gitpath') is not a Git repository, "
+        @warn "The directory ('$gitpath') is not a Git repository, "*
               "returning `nothing` instead of the commit ID."
         return nothing
     end

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -30,9 +30,15 @@ function current_commit(gitpath = projectdir())
         "returning `nothing` instead of the commit id."
         return nothing
     end
-    # then we return the current commit
+    # then we return the output of `git describe` or commit if no annotated
+    # tags are available
     repo = LibGit2.GitRepo(gitpath)
-    c = string(LibGit2.head_oid(repo))
+    c = begin try
+            split(string(LibGit2.GitDescribeResult(repo)))[2]
+        catch GitError
+            string(LibGit2.head_oid(repo))
+        end
+    end
     if LibGit2.isdirty(repo)
         @warn "The Git repository is dirty! Adding appropriate comment to "*
         "commit id..."

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -2,11 +2,11 @@ export gitdescribe, current_commit, tag!, @tag!
 export dict_list, dict_list_count
 
 """
-    gitdescribe(gitpath = projectdir()) -> git-description or commit
+    gitdescribe(gitpath = projectdir()) -> gitstr
 
-Return the output of `git describe` if an annotated git tag exists,
+Return a string `gitstr` with the output of `git describe` if an annotated git tag exists,
 otherwise the current active commit id of the Git repository present
-in `gitpath`, which by default is the project gitpath. If the repository
+in `gitpath`, which by default is the currently active project. If the repository
 is dirty when this function is called the string will end
 with `"_dirty"`.
 
@@ -21,17 +21,17 @@ latest commit hash is 334a0f225d9fba86161ab4c8892d4f023688159c, the output
 will be `v1.2.3-5-g334a0f`. Notice that git will shorten the hash if there
 are no ambiguous commits.
 
-More information about the `git describe` output can be found on 
+More information about the `git describe` output can be found on
 (https://git-scm.com/docs/git-describe)
 
 See also [`tag!`](@ref).
 
 ## Examples
 ```julia
-julia> gitdescribe()
+julia> gitdescribe() # a tag exists
 "v1.2.3-g7364ab"
 
-julia> gitdescribe()
+julia> gitdescribe() # a tag doesn't exist
 "96df587e45b29e7a46348a3d780db1f85f41de04"
 
 julia> gitdescribe(path_to_a_dirty_repo)

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -31,6 +31,9 @@ end
 @test_throws ErrorException initialize_project(path, name)
 
 initialize_project(path, name; force = true, authors = ["George", "Nick"])
+# test gitdescribe:
+com = gitdescribe(path)
+@test !occursin('-', com) # no dashes = no git describe
 
 @test projectname() == name
 for p in DrWatson.DEFAULT_PATHS

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -6,7 +6,7 @@ com = current_commit(@__DIR__)
 
 com = current_commit(dirname(@__DIR__))
 @test com !== nothing
-@test typeof(com) == String
+@test typeof(com) <: String
 
 # tag!
 d1 = Dict(:x => 3, :y => 4)
@@ -15,7 +15,7 @@ for d in (d1, d2)
     d = tag!(d, dirname(@__DIR__))
 
     @test haskey(d, keytype(d)(:commit))
-    @test d[keytype(d)(:commit)] |> typeof == String
+    @test d[keytype(d)(:commit)] |> typeof <: String
 end
 
 # @tag!
@@ -24,7 +24,7 @@ for d in (d1, d2)
     @test !haskey(d, keytype(d)(:commit))
 
     d = @tag!(d, dirname(@__DIR__))
-    @test d[keytype(d)(:commit)] |> typeof == String
+    @test d[keytype(d)(:commit)] |> typeof <: String
     @test d[keytype(d)(:script)][1:4] == "test"
 end
 

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -1,10 +1,10 @@
 using DrWatson, Test
 
 # Test commit function
-com = current_commit(@__DIR__)
+com = gitdescribe(@__DIR__)
 @test com === nothing
 
-com = current_commit(dirname(@__DIR__))
+com = gitdescribe(dirname(@__DIR__))
 @test com !== nothing
 @test typeof(com) <: String
 

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -7,7 +7,7 @@ com = gitdescribe(@__DIR__)
 com = gitdescribe(dirname(@__DIR__))
 @test com !== nothing
 @test typeof(com) <: String
-
+@test com[1] == 'v' # test that it has a version tag
 # tag!
 d1 = Dict(:x => 3, :y => 4)
 d2 = Dict("x" => 3, "y" => 4)


### PR DESCRIPTION
I use annotated Git tags (`git tag -a v0.1.2`) to mark the stage of the developments even in my research repositories and then `git describe` gives a nice human readable representation of the HEAD. I think it would be nice if this was used in `tagsave` too.

For example if `git describe` spits out this: `12.0.0-alpha.1-8-g6f60bd1d-D`, I immediately know that it's 8 commits ahead of version 12.0.0-alpha.1, it's a dirty repository (`-D`) and the last commit is `6f60bd1d`.

My PR just falls back to the commit hash if there is no annotated tags and also preserves the `_dirty` suffix. Of course now the `current_commit()` is not really referring to the `current_commit`, so the naming should be discussed also.

What do you think?