### PR TITLE
Add @savename macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.7.0
-* New macro `@savename` that it a shortcut for `savename(@dict vars...)`
+* New macro `@savename` that is a shortcut for `savename(@dict vars...)`
 # 0.6.0
 * **[BREAKING]** Reworked the way the functions `projectdir` and derivatives work (#47, #64, #66). Now `projectdir(args...)` uses `joinpath` to connect arguments. None of the functions like `projectdir` and derivatives now end in `/` as well, to ensure more stability and motivate users to use `joinpath` or the new functionality of `projectdir(args...)` instead of using string multiplication `*`.
 * New function `parse_savename` that attempts to reverse engineer the result of `savename`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.7.0
+* New macro `@savename` that it a shortcut for `savename(@dict vars...)`
 # 0.6.0
 * **[BREAKING]** Reworked the way the functions `projectdir` and derivatives work (#47, #64, #66). Now `projectdir(args...)` uses `joinpath` to connect arguments. None of the functions like `projectdir` and derivatives now end in `/` as well, to ensure more stability and motivate users to use `joinpath` or the new functionality of `projectdir(args...)` instead of using string multiplication `*`.
 * New function `parse_savename` that attempts to reverse engineer the result of `savename`.

--- a/docs/src/name.md
+++ b/docs/src/name.md
@@ -15,9 +15,10 @@ savename
 Notice that this naming scheme integrates perfectly with Parameters.jl.
 
 ## Convenience functions
-Convenience functions are provided to easily create named tuples, dictionaries as well as switch between them:
+Convenience functions are provided to shorten common function calls and easily create named tuples, dictionaries as well as switch between them:
 ```@docs
 @dict
+@savename
 @strdict
 @ntuple
 ntuple2dict

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -1,4 +1,4 @@
-export savename, @dict, @ntuple, @strdict, parse_savename
+export savename, @savename, @dict, @ntuple, @strdict, parse_savename
 export ntuple2dict, dict2ntuple
 
 """
@@ -191,6 +191,34 @@ Dict{Symbol,Any} with 3 entries:
 ```
 """
 macro dict(vars...)
+    return esc_dict_expr_from_vars(vars)
+end
+
+"""
+    @savename vars...
+Convenient combination of chaining a call to [`@dict`](@ref) on `vars` and [`savename`](@ref).
+
+## Examples
+```julia
+julia> a = 0.153456453; b = 5.0; mode = "double"
+julia> @savename a b mode
+"a=0.153_b=5_mode=double"
+```
+"""
+macro savename(vars...)
+    expr = esc_dict_expr_from_vars(vars)
+    return :(savename($expr))
+end
+
+"""
+    esc_dict_expr_from_vars(vars)
+Transform a `Tuple` of `Symbol` into a dictionary where each `Symbol` in `vars`
+defines a key-value pair. The value is obtained by evaluating the `Symbol` in
+the macro calling environment.
+
+This should only be called when producing an expression intended to be returned by a macro.
+"""
+function esc_dict_expr_from_vars(vars)
     expr = Expr(:call, :Dict)
     for i in 1:length(vars)
         push!(expr.args, :($(QuoteNode(vars[i])) => $(esc(vars[i]))))

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -22,6 +22,7 @@ n = (x = x, y = y)
 @test d == @dict x y
 @test Dict("x" => x, "y" => y) == @strdict x y
 @test n == @ntuple x y
+@test (@savename x y) == savename(d)
 
 z = "lala"
 d2 = Dict(:x => x, :y => y, :z => z)
@@ -34,6 +35,7 @@ n2 = (x = x, y = y, z= z)
 @test savename(@ntuple x y) == "x=3_y=5"
 w = rand(50)
 @test savename(@dict x y w) == savename(@dict x y)
+@test (@savename x y w) == savename(@dict x y)
 @test savename(@ntuple x y w) == savename(@dict x y)
 
 @test ntuple2dict(@ntuple x y) == @dict x y


### PR DESCRIPTION
Implements #60. Turned out to be not just calling `@dict` and then `savename`. The `args` need to be escaped before the `dict` macro call which messes up the variable names.

Closes #60 