### PR TITLE
Add proper error msg to `parse_savename`

### DIFF
--- a/src/naming.jl
+++ b/src/naming.jl
@@ -353,9 +353,12 @@ function parse_savename(filename::AbstractString;
         c_idx = end_of_value+2
     end
     # The last = cannot be followed by a connector, so it's not captured by the regex.
-    equal_sign = findnext("=",_parameters,c_idx) |> first
-    parameters[_parameters[c_idx:equal_sign-1]] =
-        parse_from_savename_value(parsetypes,_parameters[equal_sign+1:end])
+    equal_sign = findnext("=",_parameters,c_idx)
+    equal_sign == nothing && error(
+        "Savename cannot be parsed. There is a '$connector' after the last '='. "*
+        "Values containing '$connector' are not allowed when parsing.")
+    parameters[_parameters[c_idx:first(equal_sign)-1]] =
+        parse_from_savename_value(parsetypes,_parameters[first(equal_sign)+1:end])
     return prefix,parameters,suffix
 end
 

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -138,3 +138,5 @@ _prefix, _b, _suffix = DrWatson.parse_savename(joinpath("some_random_path_a=10.0
 @test _b["my_value"] == 10.1
 
 @test_throws ErrorException DrWatson.parse_savename("a=10",connector="__")
+@test_throws ErrorException("Savename cannot be parsed. There is a '_' after the last '='. "*
+        "Values containing '_' are not allowed when parsing.") DrWatson.parse_savename("a=10_1")


### PR DESCRIPTION
I noticed today that `parse_savename` throws a pretty inconclusive error msg when a `connector` appears after the last `=`.

```
julia> parse_savename("prefix_a_1=1_b=mode_a")
ERROR: MethodError: no method matching iterate(::Nothing)
```

```
julia> parse_savename("prefix_a_1=1_b=mode_a")
ERROR: Savename cannot be parsed. There is a '_' after the last '='. Values containing '_' are not allowed when parsing.
```

Also #38 can be closed