### PR TITLE
Replace GitRepo -> GitRepoExt to get repo also when using sub-dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.0
+* **[BREAKING]** : The `gitpath` argument used among many functions
+  can now also point to a subdirectory within a git repository.
+  Previously it had to be the top directory (i.e. the one containing
+  `.git/`).
+* For a dirty repository, `tag!` and friends now store a patch (aka a
+  diff) of the changes.  Thus even not-commited code changes can now
+  reproduced.  Implemented in the `gitpatch` function.
+
 # 0.8.0
 * **[BREAKING]** : Slightly changed how `produce_or_load` uses `path` and interacts with `savename`, to better incorporate the changes done in version 0.6.0. `prefix` is now also supported.
 * `tag!` and co now also store the git diff patch if the repo is dirty (#80).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
-# 1.0.0
+# 0.8.0
 * **[BREAKING]** : The `gitpath` argument used among many functions
   can now also point to a subdirectory within a git repository.
   Previously it had to be the top directory (i.e. the one containing
   `.git/`).
-* For a dirty repository, `tag!` and friends now store a patch (aka a
-  diff) of the changes.  Thus even not-commited code changes can now
-  reproduced.  Implemented in the `gitpatch` function.
-
-# 0.8.0
 * **[BREAKING]** : Slightly changed how `produce_or_load` uses `path` and interacts with `savename`, to better incorporate the changes done in version 0.6.0. `prefix` is now also supported.
-* `tag!` and co now also store the git diff patch if the repo is dirty (#80).
+* `tag!` and co now also store the git diff patch if the repo is dirty, see `gitpatch` (#80).
 * **[BREAKING]** : `tag!` now saves the commit information into a field `gitcommit` instead of just `commit`.
 
 # 0.7.1

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -41,7 +41,7 @@ julia> gitdescribe(path_to_a_dirty_repo)
 function gitdescribe(gitpath = projectdir())
     # Here we test if the gitpath is a git repository.
     try
-        repo = LibGit2.GitRepo(gitpath)
+        repo = LibGit2.GitRepoExt(gitpath)
     catch er
         @warn "The directory ('$gitpath') is not a Git repository, "*
               "returning `nothing` instead of the commit ID."
@@ -54,7 +54,7 @@ function gitdescribe(gitpath = projectdir())
     end
     # then we return the output of `git describe` or the latest commit hash
     # if no annotated tags are available
-    repo = LibGit2.GitRepo(gitpath)
+    repo = LibGit2.GitRepoExt(gitpath)
     c = try
         gdr = LibGit2.GitDescribeResult(repo)
         fopt = LibGit2.DescribeFormatOptions(dirty_suffix=pointer(suffix))
@@ -73,7 +73,7 @@ compared to its last commit; i.e. what `git diff HEAD` produces.
 """
 function gitpatch(gitpath = projectdir())
     try
-        repo = LibGit2.GitRepo(gitpath)
+        repo = LibGit2.GitRepoExt(gitpath)
     catch er
         @warn "The directory ('$gitpath') is not a Git repository, "*
               "returning `nothing` instead of a patch."
@@ -83,7 +83,7 @@ function gitpatch(gitpath = projectdir())
     # diff = LibGit2.diff_tree(repo, tree)
     # now there is no way to generate the patch with LibGit2.jl.
     # Instead use commands:
-    patch = read(`git --git-dir=$(gitpath)/.git diff HEAD`, String)
+    patch = read(`git -C $(gitpath) diff HEAD`, String)
     return patch
 end
 

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -10,7 +10,8 @@ in `gitpath`, which by default is the currently active project. If the repositor
 is dirty when this function is called the string will end
 with `"_dirty"`.
 
-Return `nothing` if `gitpath` is not a Git repository.
+Return `nothing` if `gitpath` is not a Git repository, i.e. a directory within a git
+repository.
 
 The format of the `git describe` output in general is
 
@@ -70,6 +71,8 @@ end
 
 Generates a patch describing the changes of a dirty repository
 compared to its last commit; i.e. what `git diff HEAD` produces.
+The `gitpath` needs to point to a directory within a git repository,
+otherwise `nothing` is returned.
 """
 function gitpatch(gitpath = projectdir())
     try

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -2,7 +2,7 @@ using DrWatson, Test
 
 # Test commit function
 com = gitdescribe(@__DIR__)
-@test com === nothing
+@test com isa String
 
 com = gitdescribe(dirname(@__DIR__))
 @test com !== nothing
@@ -12,7 +12,7 @@ com = gitdescribe(dirname(@__DIR__))
 d1 = Dict(:x => 3, :y => 4)
 d2 = Dict("x" => 3, "y" => 4)
 for d in (d1, d2)
-    d = tag!(d, dirname(@__DIR__))
+    d = tag!(d, @__DIR__)
 
     @test haskey(d, keytype(d)(:gitcommit))
     @test d[keytype(d)(:gitcommit)] |> typeof <: String
@@ -21,11 +21,9 @@ end
 # @tag!
 for d in (d1, d2)
     d = @tag!(d, @__DIR__)
-    @test !haskey(d, keytype(d)(:gitcommit))
-
-    d = @tag!(d, dirname(@__DIR__))
+    @test haskey(d, keytype(d)(:gitcommit))
     @test d[keytype(d)(:gitcommit)] |> typeof <: String
-    @test d[keytype(d)(:script)][1:4] == "test"
+    @test split(d[keytype(d)(:script)], '#')[1] == basename(@__FILE__)
 end
 
 # Test dictionary expansion


### PR DESCRIPTION
When doing, e.g., `gitdescribe(".")` and "." is a subdirectory to the topmost gid-dir (where `.git` is), then currently:
```
julia> gitdescribe(".")
┌ Warning: The directory ('.') is not a Git repository, returning `nothing` instead of the commit ID.
└ @ DrWatson ~/.julia/dev/DrWatson/src/saving_tools.jl:46
```
With this PR it "correctly" returns the hash of the repo.

As I haven't gotten around to trying DrWatson out, I don't know whether this is an improvement or not.  Also, if #80 gets merged, one more `GetRepo` -> `GetRepoExt` needs to be done.