### PR TITLE
Remove test directory from `initialize_project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.0
+* `initialize_project` no longer makes a test directory.
+
 # 1.0.1
 * Allow `tag!` and derivatives to handle dictionaries with *key type* `Any`.
 # 1.0.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.0.1"
+version = "1.1.0"
 
 
 [deps]

--- a/src/defaults/project_structure.txt
+++ b/src/defaults/project_structure.txt
@@ -23,9 +23,6 @@
 │                       structures and modules that are used throughout
 │                       the project and in multiple scripts.
 │
-├── test             <- Tests for code in src.
-│   └── runtests.jl  <- Script to run all tests.
-│
 ├── README.md        <- Optional top-level README for anyone using this project.
 ├── .gitignore       <- by default ignores _research, data, plots, videos,
 │                       notebooks and latex-compilation related files.

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -141,7 +141,6 @@ const DEFAULT_PATHS = [
 "_research", "src", "scripts",
 "plots", "notebooks",
 "papers",
-"test",
 joinpath("data", "sims"),
 joinpath("data", "exp_raw"),
 joinpath("data", "exp_pro"),
@@ -204,7 +203,6 @@ function initialize_project(path, name = basename(path);
     # Default files
     cp(joinpath(@__DIR__, "defaults", "gitignore.txt"), joinpath(path, ".gitignore"))
     cp(joinpath(@__DIR__, "defaults", "intro.jl"), joinpath(path, "scripts", "intro.jl"))
-    cp(joinpath(@__DIR__, "defaults", "runtests.jl"), joinpath(path, "test", "runtests.jl"))
     files = vcat(".gitignore", joinpath("scripts", "intro.jl"), joinpath("test", "runtests.jl"))
     if readme
         write(joinpath(path, "README.md"), DEFAULT_README)


### PR DESCRIPTION
Well, it just so happens that every month I find a new reason to regret merging #43. No more I will live with such regrets, I am reverting it!

---

The motivation is simple: this "test" directory is clearly targeting a Julia package. I am not sure how many scientists write consistent checks for their actual projects. I am for sure not one of them. The advantage of not having a test directory will be great: hopefully people will not tend to think that DrWatson is about Julia packages.