### PR TITLE
Improve tag functions and macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+* The functions `tag!, tagsave` and their respective macros now obtain their arguments (besides the first two) as keywords instead of positional arguments. The positional versions are deprecated (#93).
+* New keyword `force = false` for `tag!` and co. which replaces the existing `gitcommit` field.
+
 # 1.2.0
 * Improved behavior of `savename` with respect to nested containers. If a nested container is empty, it is not printed instead. For example, `T=100_p=()_x=2` now becomes `T=100_x=2`. (if `p` is not empty then it is expanded as usual)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.2.0"
+version = "1.3.0"
 
 
 [deps]

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -4,6 +4,11 @@ import Pkg, LibGit2
 
 const PATH_SEPARATOR = joinpath("_", "_")[2]
 
+# Misc functions for kw-macros
+convert_to_kw(ex::Expr) = Expr(:kw,ex.args...)
+iskwdefinition(ex) = false
+iskwdefinition(ex::Expr) = ex.head == Symbol("=")
+
 # Pure Julia implementation
 include("project_setup.jl")
 include("naming.jl")

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -81,9 +81,8 @@ establish reproducibility of results using Git. If the Git repository is dirty,
 one more field `:gitpatch` is added that stores the difference string.
 For more, see [`tag!`](@ref).
 """
-tagsave(file, d, p::String) = tagsave(file, d, false, p)
-function tagsave(file, d, safe::Bool, gitpath = projectdir(), storepatch = true, s = nothing)
-    d2 = tag!(d, gitpath, storepatch, s)
+function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, source = nothing)
+    d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, source=source)
     mkpath(dirname(file))
     if safe
         safesave(file, copy(d2))
@@ -93,8 +92,6 @@ function tagsave(file, d, safe::Bool, gitpath = projectdir(), storepatch = true,
     return d2
 end
 
-tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, source = nothing) =
-    tagsave(file, d, safe, gitpath, storepatch, source)
 
 """
     @tagsave(file::String, d::Dict [, safe = false, gitpath = projectdir()])
@@ -206,3 +203,6 @@ function tmpsave(dicts, tmp = projectdir("_research", "tmp");
     end
     r
 end
+
+@deprecate tagsave(file, d, p::String) tagsave(file, d, gitpath=p)
+@deprecate tagsave(file, d, safe::Bool, gitpath = projectdir(), storepatch = true, source = nothing) tagsave(file,d,safe=safe,gitpath=gitpath,storepatch=storepatch,source=source)

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -72,14 +72,16 @@ end
 #                             tag saving                                       #
 ################################################################################
 """
-    tagsave(file::String, d::Dict [, safe = false, gitpath = projectdir(), storepatch = true])
+    tagsave(file::String, d::Dict; safe = false, gitpath = projectdir(), storepatch = true, force = false)
 First [`tag!`](@ref) dictionary `d` and then save `d` in `file`.
 If `safe = true` save the file using [`safesave`](@ref).
 
-"Tagging" means that when saving the dictionary, an extra field `:gitcommit` is added to
-establish reproducibility of results using Git. If the Git repository is dirty,
-one more field `:gitpatch` is added that stores the difference string.
-For more, see [`tag!`](@ref).
+"Tagging" means that when saving the dictionary, an extra field
+`:gitcommit` is added to establish reproducibility of results using
+Git. If the Git repository is dirty, one more field `:gitpatch` is
+added that stores the difference string.  If a dictionary already
+contains a key `:gitcommit`, it is not overwritten, unless,
+`force=true`. For more details, see [`tag!`](@ref).
 """
 function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, force = false, source = nothing)
     d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, force=force, source=source)
@@ -94,7 +96,7 @@ end
 
 
 """
-    @tagsave(file::String, d::Dict [, safe = false, gitpath = projectdir()])
+    @tagsave(file::String, d::Dict; safe = false, gitpath = projectdir(), force = false)
 Same as [`tagsave`](@ref) but one more field `:script` is added that records
 the local path of the script and line number that called `@tagsave`, see [`@tag!`](@ref).
 """

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -81,8 +81,8 @@ establish reproducibility of results using Git. If the Git repository is dirty,
 one more field `:gitpatch` is added that stores the difference string.
 For more, see [`tag!`](@ref).
 """
-function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, source = nothing)
-    d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, source=source)
+function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, force = false, source = nothing)
+    d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, force=force, source=source)
     mkpath(dirname(file))
     if safe
         safesave(file, copy(d2))

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -82,7 +82,7 @@ one more field `:gitpatch` is added that stores the difference string.
 For more, see [`tag!`](@ref).
 """
 tagsave(file, d, p::String) = tagsave(file, d, false, p)
-function tagsave(file, d, safe = false, gitpath = projectdir(), storepatch = true, s = nothing)
+function tagsave(file, d, safe::Bool, gitpath = projectdir(), storepatch = true, s = nothing)
     d2 = tag!(d, gitpath, storepatch, s)
     mkpath(dirname(file))
     if safe
@@ -92,6 +92,9 @@ function tagsave(file, d, safe = false, gitpath = projectdir(), storepatch = tru
     end
     return d2
 end
+
+tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, s = nothing) =
+    tagsave(file, d, safe, gitpath, storepatch, s)
 
 """
     @tagsave(file::String, d::Dict [, safe = false, gitpath = projectdir()])

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -113,6 +113,9 @@ macro tagsave(file,d,args...)
         :(true),         #storepatch
     ]
     :(tagsave($(esc(file)),$(esc(d)), $(esc.(args)...), $(esc.(default[N:end])...), $s))
+    # Use this code after the deprecation warning for the non-kw version
+    # is removed.
+    # throw(MethodError(@tagsave,args...))
 end
 
 ################################################################################
@@ -208,3 +211,6 @@ end
 
 @deprecate tagsave(file, d, p::String) tagsave(file, d, gitpath=p)
 @deprecate tagsave(file, d, safe::Bool, gitpath = projectdir(), storepatch = true, source = nothing) tagsave(file,d,safe=safe,gitpath=gitpath,storepatch=storepatch,source=source)
+# TODO: When removing the deprecation warning, the tests must be adapted
+# to only use the kw-version of this function. Also the code from the
+# macro version for parsing the non-kw arguments can be replaced.

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -91,14 +91,15 @@ function gitpatch(gitpath = projectdir())
 end
 
 """
-    tag!(d::Dict, gitpath = projectdir(), storepatch = true) -> d
+    tag!(d::Dict; gitpath = projectdir(), storepatch = true, force = false) -> d
 Tag `d` by adding an extra field `gitcommit` which will have as value
 the [`gitdescribe`](@ref) of the repository at `gitpath` (by default
 the project's gitpath). Do nothing if a key `gitcommit` already exists
-or if the Git repository is not found. If the git repository is dirty,
-i.e. there are un-commited changes, then the output of `git diff HEAD`
-is stored in the field `gitpatch`.  Note that patches for binary files
-are not stored.
+(unless `force=true` then replace with the new value) or if the Git
+repository is not found. If the git repository is dirty, i.e. there
+are un-commited changes, then the output of `git diff HEAD` is stored
+in the field `gitpatch`.  Note that patches for binary files are not
+stored.
 
 Notice that if `String` is not a subtype of the value type of `d` then
 a new dictionary is created and returned. Otherwise the operation is
@@ -123,11 +124,6 @@ Dict{Symbol,Any} with 3 entries:
 ```
 """
 function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, force = false, source = nothing) where {K,T}
-    # The second argument `gitpath` must be non-optional here, because
-    # the kw-argument version of tag! would overwrite tag!(d) created
-    # here (Which still works but throws a warning).  So dispatching
-    # on tag!(d) now works through one of the methods created by the
-    # kw-version of this function.
     c = gitdescribe(gitpath)
     patch = gitpatch(gitpath)
     @assert (Symbol <: K) || (String <: K)
@@ -170,7 +166,7 @@ sourcename(s) = string(s)
 sourcename(s::LineNumberNode) = string(s.file)*"#"*string(s.line)
 
 """
-    @tag!(d, gitpath = projectdir()) -> d
+    @tag!(d, gitpath = projectdir(), storepatch = true, force = false) -> d
 Do the same as [`tag!`](@ref) but also add another field `script` that has
 the path of the script that called `@tag!`, relative with respect to `gitpath`.
 The saved string ends with `#line_number`, which indicates the line number

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -196,6 +196,9 @@ macro tag!(d,args...)
         :(true), #storepatch
     ]
     :(tag!($(esc(d)), $(esc.(args)...), $(esc.(default[N:end])...), $s))
+    # Use this code after the deprecation warning for the non-kw version
+    # is removed.
+    # throw(MethodError(@tag!,args...))
 end
 
 """
@@ -289,3 +292,6 @@ function struct2dict(s)
 end
 
 @deprecate tag!(d::Dict, gitpath, storepatch = true, source = nothing) tag!(d,gitpath=gitpath,storepatch=storepatch,source=source)
+# TODO: When removing the deprecation warning, the tests must be adapted
+# to only use the kw-version of this function. Also the code from the
+# macro version for parsing the non-kw arguments can be replaced.

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -122,8 +122,12 @@ Dict{Symbol,Any} with 3 entries:
   :x => 3
 ```
 """
-function tag!(d::Dict{K, T}, gitpath = projectdir(), storepatch = true, source = nothing) where {K, T}
-
+function tag!(d::Dict{K, T}, gitpath, storepatch = true, source = nothing) where {K, T}
+    # The second argument `gitpath` must be non-optional here, because
+    # the kw-argument version of tag! would overwrite tag!(d) created
+    # here (Which still works but throws a warning).  So dispatching
+    # on tag!(d) now works through one of the methods created by the
+    # kw-version of this function.
     c = gitdescribe(gitpath)
     patch = gitpatch(gitpath)
     @assert (Symbol <: K) || (String <: K)
@@ -161,6 +165,8 @@ function tag!(d::Dict{K, T}, gitpath = projectdir(), storepatch = true, source =
     end
     return d
 end
+
+tag!(d::Dict; gitpath = projectdir(), storepatch = true, source = nothing) = tag!(d,gitpath,storepatch,source)
 
 sourcename(s) = string(s)
 sourcename(s::LineNumberNode) = string(s.file)*"#"*string(s.line)

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -122,7 +122,7 @@ Dict{Symbol,Any} with 3 entries:
   :x => 3
 ```
 """
-function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, source = nothing) where {K,T}
+function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, force = false, source = nothing) where {K,T}
     # The second argument `gitpath` must be non-optional here, because
     # the kw-argument version of tag! would overwrite tag!(d) created
     # here (Which still works but throws a warning).  So dispatching
@@ -138,7 +138,7 @@ function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, source = 
     end
 
     c === nothing && return d # gitpath is not a git repo
-    if haskey(d, commitname)
+    if haskey(d, commitname) && !force
         @warn "The dictionary already has a key named `gitcommit`. We won't "*
         "add any Git information."
         return d
@@ -155,7 +155,7 @@ function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, source = 
             d[patchname] = patch
         end
     end
-    if source != nothing
+    if source != nothing && !force
         if haskey(d, scriptname)
             @warn "The dictionary already has a key named `script`. We won't "*
             "overwrite it with the script name."

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -122,7 +122,7 @@ Dict{Symbol,Any} with 3 entries:
   :x => 3
 ```
 """
-function tag!(d::Dict{K, T}, gitpath, storepatch = true, source = nothing) where {K, T}
+function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, source = nothing) where {K,T}
     # The second argument `gitpath` must be non-optional here, because
     # the kw-argument version of tag! would overwrite tag!(d) created
     # here (Which still works but throws a warning).  So dispatching
@@ -165,8 +165,6 @@ function tag!(d::Dict{K, T}, gitpath, storepatch = true, source = nothing) where
     end
     return d
 end
-
-tag!(d::Dict; gitpath = projectdir(), storepatch = true, source = nothing) = tag!(d,gitpath,storepatch,source)
 
 sourcename(s) = string(s)
 sourcename(s::LineNumberNode) = string(s.file)*"#"*string(s.line)
@@ -293,3 +291,5 @@ tagsave(savename(s), struct2dict(s))
 function struct2dict(s)
     Dict(x => getfield(s, x) for x in fieldnames(typeof(s)))
 end
+
+@deprecate tag!(d::Dict, gitpath, storepatch = true, source = nothing) tag!(d,gitpath=gitpath,storepatch=storepatch,source=source)

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -190,9 +190,18 @@ Dict{Symbol,Any} with 3 entries:
   :x      => 3
 ```
 """
-macro tag!(d, gitpath = projectdir(), storepatch = true)
+macro tag!(d,args...)
     s = QuoteNode(__source__)
-    :(tag!($(esc(d)), $(esc(gitpath)), $(esc(storepatch)), $s))
+    N = length(args)
+    (N == 0 || all(iskwdefinition.(args))) &&
+        return :(tag!($(esc(d)),$(esc.(convert_to_kw.(args))...),source=$s))
+    # First optional arg. is not needed as if it's not provided dispatch
+    # is done through the kw-version of the function (ie. this line is
+    # never reached)
+    default = [
+        :(true), #storepatch
+    ]
+    :(tag!($(esc(d)), $(esc.(args)...), $(esc.(default[N:end])...), $s))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using DrWatson, Test
 
-@testset "Naming" begin include("naming_tests.jl"); end
-@testset "Parse savename" begin include("parse_tests.jl"); end
-@testset "Project Setup" begin include("project_tests.jl"); end
-@testset "Saving tools" begin include("stools_tests.jl"); end
-@testset "Produce or Save" begin include("savefiles_tests.jl"); end
-@testset "Collect Results" begin include("update_results_tests.jl"); end
-@testset "Parameter Customization" begin include("customize_savename.jl"); end
+@testset "DrWatson" begin
+    @testset "Naming" begin include("naming_tests.jl"); end
+    @testset "Parse savename" begin include("parse_tests.jl"); end
+    @testset "Project Setup" begin include("project_tests.jl"); end
+    @testset "Saving tools" begin include("stools_tests.jl"); end
+    @testset "Produce or Save" begin include("savefiles_tests.jl"); end
+    @testset "Collect Results" begin include("update_results_tests.jl"); end
+    @testset "Parameter Customization" begin include("customize_savename.jl"); end
+end

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -47,8 +47,11 @@ sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
 rm(sn)
 
 t = f(simulation)
-@tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())
-sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
+t["gitcommit"] = ""
+@test @tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())["gitcommit"] == ""
+@test isfile(sn)
+rm(sn)
+@test @tagsave(savename(simulation, "bson"), t, safe=true, force=true, gitpath=findproject())["gitcommit"] != ""
 @test isfile(sn)
 rm(sn)
 
@@ -62,6 +65,8 @@ ex = @macroexpand @tagsave("name",d,false)
 @test ex.args[4] == false
 @test ex.args[5] == :(projectdir())
 @test ex.args[6] == true
+
+# Remove leftover
 
 ################################################################################
 #                              produce or load                                 #

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -38,10 +38,16 @@ t = f(simulation)
 @tagsave(savename(simulation, "bson"), t, true, findproject())
 sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
 @test isfile(sn)
-rm(savename(simulation, "bson"))
 rm(sn)
-@test !isfile(savename(simulation, "bson"))
 
+t = f(simulation)
+tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())
+sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
+@test isfile(sn)
+rm(sn)
+
+rm(savename(simulation, "bson"))
+@test !isfile(savename(simulation, "bson"))
 ################################################################################
 #                              produce or load                                 #
 ################################################################################

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -46,8 +46,23 @@ sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
 @test isfile(sn)
 rm(sn)
 
+t = f(simulation)
+@tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())
+sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
+@test isfile(sn)
+rm(sn)
+
 rm(savename(simulation, "bson"))
 @test !isfile(savename(simulation, "bson"))
+
+ex = @macroexpand @tagsave("name",d,false)
+@test ex.args[1].name == :tagsave
+@test ex.args[2] == "name"
+@test ex.args[3] == :d
+@test ex.args[4] == false
+@test ex.args[5] == :(projectdir())
+@test ex.args[6] == true
+
 ################################################################################
 #                              produce or load                                 #
 ################################################################################

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -26,6 +26,16 @@ for d in (d1, d2)
     @test split(d[keytype(d)(:script)], '#')[1] == basename(@__FILE__)
 end
 
+# Tag kw-functions
+
+d = Dict(:x => 3, :y => 4)
+d_new = tag!(d)
+
+@test d == d_new
+
+d_new = tag!(d,gitpath=@__DIR__,source="foo")
+@test endswith(d_new[:script],"foo")
+
 # Test dictionary expansion
 c = Dict(:a => [1, 2], :b => 4);
 c1 = [ Dict(:a=>1,:b=>4)

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -36,6 +36,38 @@ d_new = tag!(d)
 d_new = tag!(d,gitpath=@__DIR__,source="foo")
 @test endswith(d_new[:script],"foo")
 
+d_new = @tag!(d,gitpath=@__DIR__)
+@test split(d_new[keytype(d_new)(:script)], '#')[1] == basename(@__FILE__)
+
+ex = @macroexpand @tag!(d)
+
+@test ex.args[1].name == :tag!
+@test ex.args[2] == :d
+@test ex.args[3].head == :kw
+
+ex = @macroexpand @tag!(d,"path")
+
+@test ex.args[1].name == :tag!
+@test ex.args[2] == :d
+@test ex.args[3] == "path"
+@test ex.args[4] == true
+
+ex = @macroexpand @tag!(d,"path",false)
+
+@test ex.args[1].name == :tag!
+@test ex.args[2] == :d
+@test ex.args[3] == "path"
+@test ex.args[4] == false
+
+ex = @macroexpand @tag!(d,gitpath="path")
+
+@test ex.args[1].name == :tag!
+@test ex.args[2] == :d
+@test ex.args[3].head == :kw
+@test ex.args[3].args[1] == :gitpath
+@test ex.args[3].args[2] == "path"
+@test ex.args[4].head == :kw
+
 # Test dictionary expansion
 c = Dict(:a => [1, 2], :b => 4);
 c1 = [ Dict(:a=>1,:b=>4)

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -68,6 +68,14 @@ ex = @macroexpand @tag!(d,gitpath="path")
 @test ex.args[3].args[2] == "path"
 @test ex.args[4].head == :kw
 
+# Test force kw
+
+d = Dict(:x => 3, :y => 4, :gitcommit => "")
+@test tag!(d,gitpath=@__DIR__)[:gitcommit] == ""
+@test tag!(d,gitpath=@__DIR__,force=true)[:gitcommit] == com
+d = Dict(:x => 3, :y => 4, :gitcommit => "")
+@test (@tag!(d, gitpath=@__DIR__,force=true))[:gitcommit] == com
+
 # Test dictionary expansion
 c = Dict(:a => [1, 2], :b => 4);
 c1 = [ Dict(:a=>1,:b=>4)


### PR DESCRIPTION
Implements #84. I'll also add #83, so this is still a draft.

The problems with having kw and non-kw versions are the following:

**Methods:** The definition of the kw-function also creates a method without the keywords. However, this method is also defined by the optional args function defintion. So on `using` you get a warning that the method is overwritten. My solution here is to define one additional argument, in the non-kw function, as mandatory. So dispatch works like this now:
- If this argument is not given -> dispatch on the kw-version
- If it is given -> dispatch on the non-kw-version

**Macros:** This one is a little tricky. During dispatch one can't tell if the passed `args...` to the macro are kw-definitions or not eg:
```
julia> :(@__DIR__)|>typeof
Expr
julia> :(x=10)|>typeof
Expr
```
The solution now basically works like this.
1. Collect mandatory and optional arguments
2. Check if all optional arguments could be kw-definitions
3. If yes, splat them as keywords
3. If no, splat them in order they were given and then splat the remaining optional arguments, if any.