### PR TITLE
making usable module docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8.0
+* `@quickactivate` was enhanced to allow projects that also represent a module.
+
 # 1.7.0
 * Improve the introductory file created by DrWatson.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.7.1"
+version = "1.8.0"
 
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Pkg
 Pkg.activate(@__DIR__)
-
+CI = get(ENV, "CI", nothing) == "true"
 using DrWatson
 using Documenter, DataFrames, Parameters, Dates, BSON, JLD2
 
@@ -12,7 +12,7 @@ sitename= "DrWatson",
 authors = "George Datseris and contributors.",
 doctest = false,
 format = Documenter.HTML(
-    prettyurls = get(ENV, "CI", nothing) == "true",
+    prettyurls = CI,
     assets = ["assets/logo.ico"],
     ),
 pages = [
@@ -25,7 +25,7 @@ pages = [
     ],
 )
 
-if get(ENV, "CI", nothing) == "true"
+if CI
     deploydocs(repo = "github.com/JuliaDynamics/DrWatson.jl.git",
                target = "build")
 end

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -33,7 +33,8 @@ save(datadir("sim", "barkley", "astonishing_results.bson"), data)
 ```
 
 ## Making your project a usable module
-For some projects, it is quite often the case that some packages and files from the source folder are loaded at the beginning of _every file of the project_. For example, I have a project that I know that for any script I will write, the first five lines will be:
+For some projects, it is often the case that some packages and files from the source folder are loaded at the beginning of _every file of the project_.
+For example, I have a project that I know that for _any_ script I will write, the first five lines will be:
 ```julia
 using DrWatson
 @quickactivate "AlbedoProperties"
@@ -41,9 +42,9 @@ using Dates, Statistics, NCDatasets
 include(srcdir("core.jl"))
 include(srcdir("style.jl"))
 ```
-This is guaranteed for every file. I think that it would be quite convenient to group all of these commands into one file and instead load that file, for example do `include(srcdir("everything.jl"))` and all commands are in there.
+It would be quite convenient to group all of these commands into one file and instead load that file, for example do `include(srcdir("everything.jl"))` and all commands are in there.
 
-We can do even better though! Because of the way Julia handles package and module paths, it is in fact possible to transform the currently active project into a usable module. If one defines inside the source folder a file `AlbedoProperties.jl` and in that file define a module `AlbedoProperties` (notice that these names must match _exactly_ the project name), then upon doing `using AlbedoProperties` Julia will in fact just bring this module into scope.
+We can do even better though! Because of the way Julia handles project and module paths, it is in fact possible to transform the currently active project into a usable module. If one defines inside the `src` folder a file `AlbedoProperties.jl` and in that file define a module `AlbedoProperties` (notice that these names must match _exactly_ the project name), then upon doing `using AlbedoProperties` Julia will in fact just bring this module into scope.
 
 So what I end up doing (for some projects where this makes sense) is creating the aforementioned file and putting inside things like
 ```julia
@@ -63,7 +64,9 @@ and then the header of all my files is transformed to
 using DrWatson
 @quickactivate :AlbedoProperties
 ```
-(notice that the above code takes advantage of [`@quickactivate`](@ref)'s feature to essentially combine the commands `@quickactivate "AlbedoProperties"` and `using AlbedoProperties` into one).
+which takes advantage of [`@quickactivate`](@ref)'s feature to essentially combine the commands `@quickactivate "AlbedoProperties"` and `using AlbedoProperties` into one.
+
+If you intend to share your project with a non-DrWatson user, you should consider the verbose syntax instead, as the above syntax is not really clear for someone that doesn't know what `@quickactivate` does.
 
 ## `savename` and tagging
 The combination of using [`savename`](@ref) and [`tagsave`](@ref) makes it easy and fast to save output in a way that is consistent, robust and reproducible. Here is an example from a project:

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -12,7 +12,7 @@ include(srcdir("unitcells.jl"))
 ```
 In all projects I save data/plots using `datadir/plotdir`:
 ```julia
-@tagsave(datadir("mushrooms, "Λ_N=$N.bson"), (@dict Λ Λσ ws hs description))
+@tagsave(datadir("mushrooms", "Λ_N=$N.bson"), (@dict Λ Λσ ws hs description))
 ```
 The advantage of this approach is that it will always work regardless of if I move the specific file to a different subfolder (which is very often necessary) or whether I move the entire project folder somewhere else!
 **Please be sure you have understood the caveat of using [`quickactivate`](@ref)!**
@@ -25,12 +25,45 @@ using Parameters
 using TimeseriesPrediction, LinearAlgebra, Statistics
 
 include(srcdir("systems", "barkley.jl"))
-include(srcdir("nrmse.jl")
+include(srcdir("nrmse.jl"))
 
 # stuff...
 
 save(datadir("sim", "barkley", "astonishing_results.bson"), data)
 ```
+
+## Making your project a usable module
+For some projects, it is quite often the case that some packages and files from the source folder are loaded at the beginning of _every file of the project_. For example, I have a project that I know that for any script I will write, the first five lines will be:
+```julia
+using DrWatson
+@quickactivate "AlbedoProperties"
+using Dates, Statistics, NCDatasets
+include(srcdir("core.jl"))
+include(srcdir("style.jl"))
+```
+This is guaranteed for every file. I think that it would be quite convenient to group all of these commands into one file and instead load that file, for example do `include(srcdir("everything.jl"))` and all commands are in there.
+
+We can do even better though! Because of the way Julia handles package and module paths, it is in fact possible to transform the currently active project into a usable module. If one defines inside the source folder a file `AlbedoProperties.jl` and in that file define a module `AlbedoProperties` (notice that these names must match _exactly_ the project name), then upon doing `using AlbedoProperties` Julia will in fact just bring this module into scope.
+
+So what I end up doing (for some projects where this makes sense) is creating the aforementioned file and putting inside things like
+```julia
+module AlbedoProperties
+
+using Reexport
+@reexport using Dates, Statistics
+using NCDatasets: NCDataset, dimnames, NCDatasets
+export NCDataset, dimnames
+include("core.jl") # this file now also has export statements
+include("style.jl")
+
+end
+```
+and then the header of all my files is transformed to
+```julia
+using DrWatson
+@quickactivate AlbedoProperties
+```
+(notice that the above code takes advantage of [`@quickactivate`](@ref)'s feature to essentially combine the commands `@quickactivate "AlbedoProperties"` and `using AlbedoProperties` into one).
 
 ## `savename` and tagging
 The combination of using [`savename`](@ref) and [`tagsave`](@ref) makes it easy and fast to save output in a way that is consistent, robust and reproducible. Here is an example from a project:

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -61,7 +61,7 @@ end
 and then the header of all my files is transformed to
 ```julia
 using DrWatson
-@quickactivate AlbedoProperties
+@quickactivate :AlbedoProperties
 ```
 (notice that the above code takes advantage of [`@quickactivate`](@ref)'s feature to essentially combine the commands `@quickactivate "AlbedoProperties"` and `using AlbedoProperties` into one).
 

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -40,8 +40,8 @@ function __init__()
 end
 
 # Update messages
-const display_update = false
-const update_version = "1.0.0"
+const display_update = true
+const update_version = "1.8.0"
 const update_name = "update_v$update_version"
 if display_update
 if !isfile(joinpath(@__DIR__, update_name))
@@ -49,9 +49,7 @@ printstyled(stdout,
 """
 \nUpdate message: DrWatson v$update_version
 
-Welcome to the first major release!
-
-Checkout the CHANGELOG for breaking changes.
+A cool new feature was added to the `@quickactivate` macro!
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -114,14 +114,14 @@ it matches the `name`.
 
     **In addition please be very careful to write:**
     ```julia
-    using DrWatson
+    using DrWatson # YES
     quickactivate(@__DIR__)
     using Package1, Package2
     # do stuff
     ```
     **instead of the erroneous:**
     ```julia
-    using DrWatson, Package1, Package2
+    using DrWatson, Package1, Package2 # NO!
     quickactivate(@__DIR__)
     # do stuff
     ```
@@ -148,10 +148,10 @@ end
     @quickactivate
 Equivalent with `quickactivate(@__DIR__)`.
 
-    @quickactivate name
+    @quickactivate name::String
 Equivalent with `quickactivate(@__DIR__, name)`.
 """
-macro quickactivate(name = nothing)
+macro quickactivate(name::String = nothing)
     if __source__.file === nothing
         dir = nothing
     else
@@ -159,6 +159,19 @@ macro quickactivate(name = nothing)
         dir = isempty(_dirname) ? pwd() : abspath(_dirname)
     end
     :(quickactivate($dir,$name))
+end
+
+macro quickactivate(name::Symbol)
+    if __source__.file === nothing
+        dir = nothing
+    else
+        _dirname = dirname(String(__source__.file))
+        dir = isempty(_dirname) ? pwd() : abspath(_dirname)
+    end
+    quote
+        quickactivate($dir, string($name))
+        using $name
+    end
 end
 
 ##########################################################################################

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -165,6 +165,14 @@ macro quickactivate(name = nothing)
     :(quickactivate($dir,$name))
 end
 
+"""
+    @quickactivate ProjectName::Symbol
+If given a `Symbol` then first `quickactivate(@__DIR__, string(ProjectName))`,
+and then do `using ProjectName`, as if the symbol was representing a module name.
+
+This ties with [Making your project a usable module](@ref) functionality,
+see the docs for an example.
+"""
 macro quickactivate(name::QuoteNode)
     dir = get_dir_from_source(__source__.file)
     quote

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -144,6 +144,15 @@ function quickactivate(path, name = nothing)
     return nothing
 end
 
+function get_dir_from_source(source_file)
+    if source_file === nothing
+        return nothing
+    else
+        _dirname = dirname(String(source_file))
+        return isempty(_dirname) ? pwd() : abspath(_dirname)
+    end
+end
+
 """
     @quickactivate
 Equivalent with `quickactivate(@__DIR__)`.
@@ -151,26 +160,16 @@ Equivalent with `quickactivate(@__DIR__)`.
     @quickactivate name::String
 Equivalent with `quickactivate(@__DIR__, name)`.
 """
-macro quickactivate(name::String = nothing)
-    if __source__.file === nothing
-        dir = nothing
-    else
-        _dirname = dirname(String(__source__.file))
-        dir = isempty(_dirname) ? pwd() : abspath(_dirname)
-    end
+macro quickactivate(name = nothing)
+    dir = get_dir_from_source(__source__.file)
     :(quickactivate($dir,$name))
 end
 
-macro quickactivate(name::Symbol)
-    if __source__.file === nothing
-        dir = nothing
-    else
-        _dirname = dirname(String(__source__.file))
-        dir = isempty(_dirname) ? pwd() : abspath(_dirname)
-    end
+macro quickactivate(name::QuoteNode)
+    dir = get_dir_from_source(__source__.file)
     quote
         quickactivate($dir, string($name))
-        using $name
+        using $(name.value)
     end
 end
 

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -1,6 +1,6 @@
 using Pkg, Test, DrWatson
 
-cd()
+cd() # changes directory to `homedir()`
 path = "test project"
 name = "lala"
 
@@ -48,9 +48,6 @@ com = gitdescribe(path)
 for p in DrWatson.DEFAULT_PATHS
     @test ispath(joinpath(path, p))
 end
-@test isfile(joinpath(path, ".gitignore"))
-@test isfile(joinpath(path, "README.md"))
-@test isfile(joinpath(path, "Project.toml"))
 z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"George\", \"Nick\"]", z)
 z = read(joinpath(path, "scripts", "intro.jl"), String)
@@ -60,6 +57,10 @@ initialize_project(path, name; force = true, authors = "Sophia", git = false)
 @test !isdir(joinpath(path, ".git"))
 z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"Sophia\"]", z)
+
+# here we test quickactivate
+quickactivate(joinpath(homedir(), path))
+@test projectname() == name
 
 cd(path)
 @test findproject(pwd()) == pwd()


### PR DESCRIPTION
Alright, so here I am both writing some useful docs, as well as trying to add a new feature. So, when reading the docs you will see why I find this useful. I make some projects (that are very specific and thus I always use the same packages/etc.) usable modules.

Now, what I am trying to extend is to be able to create a macro so that 
```julia
@quickactivate ProjectName
```
somehow expands to
```julia
quickactivate(@__DIR__, string(ProjectName)
using ProjectName
```
I have a suspicion that this is not possible to do really with `ProjectName`, because this is undefined when we call the macro... BUT, it is certainly possible to do using Symbols, i.e.
```julia
@quickactivate :ProjectName
```
the problem is, I haven't succeeded yet in doing so...  I am testing the current code in my own project by writing 
```julia
using DrWatson
@quickactivate :AlbedoProperties
```
but alas, it errors
```
ERROR: There was an error during testing
ERROR: LoadError: MethodError: no method matching @quickactivate(::LineNumberNode, ::Module, ::QuoteNode)
Closest candidates are:
  @quickactivate(::LineNumberNode, ::Module, ::Symbol) at C:\Users\datse\.julia\dev\DrWatson\src\project_setup.jl:165
  @quickactivate(::LineNumberNode, ::Module, ::String) at C:\Users\datse\.julia\dev\DrWatson\src\project_setup.jl:155
  @quickactivate(::LineNumberNode, ::Module) at C:\Users\datse\.julia\dev\DrWatson\src\project_setup.jl:155
in expression starting at C:\Users\datse\ownCloud\Science Projects\AlbedoProperties\scripts\diff_vs_time.jl:3
```
@sebastianpech you have worked a bit with macros before, perhaps you have some input?