### PR TITLE
add new function struct2dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# 1.10.0
+* New function `struct2ntuple` that converts a struct to a NamedTuple (for saving)
+
 # 1.9.0
 * `savename` now has the `ignore` option.
-* New function `struct2ntuple` that converts a struct to a NamedTuple (for saving)
 
 # 1.8.0
 * `@quickactivate` was enhanced to allow projects that also represent a module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.9.0
 * `savename` now has the `ignore` option.
+* New function `struct2ntuple` that converts a struct to a NamedTuple (for saving)
 
 # 1.8.0
 * `@quickactivate` was enhanced to allow projects that also represent a module.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.9.2"
+version = "1.10.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/docs/src/save.md
+++ b/docs/src/save.md
@@ -64,4 +64,5 @@ See [Stopping "Did I run this?"](@ref) for an example usage of `produce_or_load`
 [`savename`](@ref) gives great support for getting a name out of any Julia composite type. To save something though, one needs a dictionary. So the following function can be conveniently used to directly save a struct using any saving function:
 ```@docs
 struct2dict
+struct2ntuple
 ```

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -302,3 +302,14 @@ tagsave(savename(s), struct2dict(s))
 function struct2dict(s)
     Dict(x => getfield(s, x) for x in fieldnames(typeof(s)))
 end
+
+export struct2ntuple
+
+"""
+    struct2ntuple(s) -> n
+Convert a Julia composite type `s` to a NamedTuple `n`.
+"""
+function struct2ntuple(s)
+    d = Dict(x => getfield(s, x) for x in fieldnames(typeof(s)))
+    NamedTuple{Tuple(keys(d))}(values(d))
+end

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -310,6 +310,5 @@ export struct2ntuple
 Convert a Julia composite type `s` to a NamedTuple `n`.
 """
 function struct2ntuple(s)
-    d = Dict(x => getfield(s, x) for x in fieldnames(typeof(s)))
-    NamedTuple{Tuple(keys(d))}(values(d))
+    NamedTuple{fieldnames(typeof(s))}(( getfield(s, x) for x in fieldnames(typeof(s))))
 end

--- a/test/customize_savename.jl
+++ b/test/customize_savename.jl
@@ -46,6 +46,12 @@ for x in fieldnames(typeof(e1))
     @test d[x] == getfield(e1, x)
 end
 
+nt = struct2ntuple(e1)
+@test isa(nt, NamedTuple)
+for x in fieldnames(typeof(e1))
+    @test nt[x] == getfield(e1, x)
+end
+
 # Test extra dir and default_prefix:
 s = savename(joinpath("path", "to", "data"), e1)
 @test s[1:4] == "path"


### PR DESCRIPTION
Closes #138 .

Adds a new function `struct2dict`.

# Testing

Added tests to `test/customize_savename.jl`  which seem to run okay.

```
$ ~/julia/julia test/customize_savename.jl 
┌ Warning:     Path separators in `savename` prefixes may break reproducibility on other OS.
│     The recommended way is using the `*dir()` methods or `joinpath` with
│     `savename` (e.g. `datadir("path", "to", "folder", savename("prefix", data))`).
└ @ DrWatson ~/DrWatson.jl/src/naming.jl:87
```