### PR TITLE
Support keyword arguments in `wsave` and `wload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.12.0
+* `wsave/wload` now support keyword arguments.
+# 1.11.0
+* Macros `@pack!, @unpack` are re-exported by DrWatson.
+
 # 1.10.0
 * New function `struct2ntuple` that converts a struct to a NamedTuple (for saving)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -21,16 +21,20 @@ using FileIO
 export save, load
 export wsave, wload
 
-_wsave(filename, obj) = FileIO.save(filename, obj)
+_wsave(filename, data...; kwargs...) = FileIO.save(filename, data...; kwargs...)
 
 """
-    wsave(filename, obj)
-Save `obj` at `filename` via `FileIO` by first creating the appropriate paths.
+    wsave(filename, data...; kwargs...)
+
+Save `data` at `filename` via `FileIO` by first creating the appropriate paths.
 """
-wsave(filename, obj) = (mkpath(dirname(filename)); _wsave(filename, obj))
+function wsave(filename, data...; kwargs...)
+    mkpath(dirname(filename))
+    return _wsave(filename, data...; kwargs...)
+end
 
 "Currently equivalent with `FileIO.load`."
-wload(args...) = FileIO.load(args...)
+wload(data...; kwargs...) = FileIO.load(data...; kwargs...)
 
 include("saving_files.jl")
 

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -26,7 +26,9 @@ _wsave(filename, data...; kwargs...) = FileIO.save(filename, data...; kwargs...)
 """
     wsave(filename, data...; kwargs...)
 
-Save `data` at `filename` via `FileIO` by first creating the appropriate paths.
+Save `data` at `filename` by first creating the appropriate paths.
+Default fallback is `FileIO.save`. Extend `wsave` for your type
+by extending `DrWatson._wsave`.
 """
 function wsave(filename, data...; kwargs...)
     mkpath(dirname(filename))


### PR DESCRIPTION
I noticed that it's currently not possible to use `wsave` with keyword arguments (needed, e.g., when setting the output resolution in CairoMakie: https://github.com/JuliaPlots/CairoMakie.jl#saving).