### PR TITLE
Make savename work with `Inf` and `NaN` values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.13.1"
+version = "1.13.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -137,6 +137,9 @@ and `scientific` the number of significant digits used for rounding.
 """
 function roundval(val::Tv;digits::Td, scientific::Ts) where {Tv, Td, Ts}
     if Tv <: AbstractFloat
+        if isnan(val) || isinf(val)
+            return val
+        end
         if Ts <: Int
             x = round(val,sigdigits = scientific)
         else

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -110,3 +110,12 @@ _,parsed,_ = parse_savename(sn)
 sn = savename(di,scientific=1)
 _,parsed,_ = parse_savename(sn)
 @test parsed["a"] == 1.0e-7
+
+
+# Test for NaN and Inf compatibility
+let
+    a = Inf
+    b = NaN
+    di = @dict a b
+    @test savename(di) == "a=Inf_b=NaN"
+end


### PR DESCRIPTION
Currently `savename` errors when you try to use it with `Inf` or `NaN` floats.
(The issue happens when trying to round to a certain number of digits)