### PR TITLE
Use relpath in collect_results!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.14.5
+* new keyword argument `rpath` for `collect_results!` that allows storing relative paths
 # 1.14.0
 * New macro `@onlyif` that allows placing restrictions on values in a dictionary used for expansion with `dict_list`
 # 1.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.14.5
+# 1.14.6
 * new keyword argument `rpath` for `collect_results!` that allows storing relative paths
 # 1.14.0
 * New macro `@onlyif` that allows placing restrictions on values in a dictionary used for expansion with `dict_list`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.14.5"
+version = "1.14.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -36,6 +36,8 @@ See also [`collect_results`](@ref).
   for result-files.
 * `valid_filetypes = [".bson", ".jld", ".jld2"]`: Only files that have these
   endings are interpreted as result-files. Other files are skipped.
+* `rpath = nothing` : If not `nothing` stores `relpath(file,rpath)` of result-files
+  in `df`. By default the absolute path is used.
 * `verbose = true` : Print (using `@info`) information about the process.
 * `white_list` : List of keys to use from result file. By default
   uses all keys from all loaded result-files.

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -103,11 +103,11 @@ function collect_results!(filename, folder;
     for file ∈ allfiles
         is_valid_file(file, valid_filetypes) || continue
         # maybe use relative path
-        file = isnothing(rpath) ? file : relpath(file, rpath)
+        file = rpath === nothing ? file : relpath(file, rpath)
         #already added?
         file ∈ existing_files && continue
 
-        data = isnothing(rpath) ? wload(file) : wload(joinpath(rpath, file))
+        data = rpath === nothing ? wload(file) : wload(joinpath(rpath, file))
         df_new = to_data_row(data, file; kwargs...)
         #add filename
         df_new[!, :path] .= file

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -71,6 +71,7 @@ folder; kwargs...)
 function collect_results!(filename, folder;
     valid_filetypes = [".bson", "jld", ".jld2"],
     subfolders = false,
+    rpath = nothing,
     verbose = true,
     newfile = false, # keyword only for defining collect_results without !
     kwargs...)
@@ -88,7 +89,7 @@ function collect_results!(filename, folder;
         allfiles = String[]
         for (root, dirs, files) in walkdir(folder)
             for file in files
-                push!(allfiles, relpath(joinpath(root,file), datadir()))
+                push!(allfiles, joinpath(root,file))
             end
         end
     else
@@ -99,10 +100,12 @@ function collect_results!(filename, folder;
     existing_files = "path" in string.(names(df)) ? df[:,:path] : ()
     for file ∈ allfiles
         is_valid_file(file, valid_filetypes) || continue
+        # maybe use relative path
+        file = isnothing(rpath) ? file : relpath(file, rpath)
         #already added?
         file ∈ existing_files && continue
 
-        data = wload(datadir(file))
+        data = isnothing(rpath) ? wload(file) : wload(joinpath(rpath, file))
         df_new = to_data_row(data, file; kwargs...)
         #add filename
         df_new[!, :path] .= file

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -88,7 +88,7 @@ function collect_results!(filename, folder;
         allfiles = String[]
         for (root, dirs, files) in walkdir(folder)
             for file in files
-                push!(allfiles, joinpath(root,file))
+                push!(allfiles, relpath(joinpath(root,file), datadir()))
             end
         end
     else
@@ -102,7 +102,7 @@ function collect_results!(filename, folder;
         #already added?
         file ∈ existing_files && continue
 
-        data = wload(file)
+        data = wload(datadir(file))
         df_new = to_data_row(data, file; kwargs...)
         #add filename
         df_new[!, :path] .= file

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -51,6 +51,13 @@ for n in ("a", "b", "lv_mean")
     @test n ∈ String.(names(cres))
 end
 @test "c" ∉ names(cres)
+@test all(startswith.(cres[!,"path"], projectdir()))
+
+relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder)).bson")
+cres_relpath = collect_results!(relpathname, folder;
+    subfolders = true, special_list=special_list, black_list = black_list,
+    rpath = projectdir())
+@info all(startswith.(cres[!,"path"], "data"))
 
 ###############################################################################
 #                           Add another file in a sub sub folder              #


### PR DESCRIPTION
Addresses #116 

Removes `datadir()` from the path entry before adding a row to the collected results dataframe. I can change it to remove only `projectdir` instead, using the data directory just seemed more natural to me.