### PR TITLE
Add a "sort" option to `savename`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.16.0
+* Add a `sort` option to `savename`.
 # 1.15.0
 * Better default readme file for a new project.
 # 1.14.6

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.15.1"
+version = "1.16.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -15,7 +15,7 @@ The function chains keys and values into a string of the form:
 ```julia
 key1=val1_key2=val2_key3=val3
 ```
-while the keys are **always sorted alphabetically** by default. If you provide
+while the keys are **sorted alphabetically** by default. If you provide
 the prefix/suffix the function will do:
 ```julia
 prefix_key1=val1_key2=val2_key3=val3.suffix
@@ -59,8 +59,9 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   called with its default arguments (so customization here is possible only
   by rolling your own container type). If the `savename` of the nested
   containers is `""`, it is also skipped.
-* `sort = true` : Indicate whether the pairs are sorted alphabetically
-  by keys.
+* `sort = true` : Indicate whether the pairs are sorted alphabetically by
+  keys. If not, they are sorted by the order of `accesses`. WARNING: the 
+  default `accesses` is not deterministic for `Dict` inputs.
 
 ## Examples
 ```julia

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -15,7 +15,7 @@ The function chains keys and values into a string of the form:
 ```julia
 key1=val1_key2=val2_key3=val3
 ```
-while the keys are **always sorted alphabetically.** If you provide
+while the keys are **always sorted alphabetically** by default. If you provide
 the prefix/suffix the function will do:
 ```julia
 prefix_key1=val1_key2=val2_key3=val3.suffix
@@ -59,6 +59,8 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   called with its default arguments (so customization here is possible only
   by rolling your own container type). If the `savename` of the nested
   containers is `""`, it is also skipped.
+* `sort = true` : Indicate whether the pairs are sorted alphabetically
+  by keys.
 
 ## Examples
 ```julia
@@ -82,7 +84,8 @@ function savename(prefix::String, c, suffix::String;
                   allowedtypes = default_allowed(c),
                   accesses = allaccess(c), ignores = allignore(c), digits = 3,
                   connector = "_", expand::Vector{String} = default_expand(c),
-                  scientific::Union{Int,Nothing}=nothing)
+                  scientific::Union{Int,Nothing}=nothing,
+                  sort = true)
 
     if any(sep in prefix for sep in ['/', '\\'])
         @warn """
@@ -101,7 +104,7 @@ function savename(prefix::String, c, suffix::String;
     # Perform access and ignore logic and sort
     labels = vecstring(accesses) # make it vector of strings
     ignored_labels = vecstring(ignores)
-    p = sortperm(labels)
+    p = sort ? sortperm(labels) : 1:length(labels)
     first = prefix == "" || endswith(prefix, PATH_SEPARATOR)
     s = prefix
     for j ∈ p

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -17,7 +17,7 @@ tday = today()
 rick = (never = "gonna", give = "you", up = "!");
 @test savename(rick) == "give=you_never=gonna_up=!"
 @test savename(rick; ignores = ["up"]) == "give=you_never=gonna"
-@test savename(rick, sort = false) == "never=gonna_give=you_up=!"
+@test savename(rick; sort = false) == "never=gonna_give=you_up=!"
 
 x = 3; y = 5.0;
 d = Dict(:x => x, :y => y)

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -17,6 +17,7 @@ tday = today()
 rick = (never = "gonna", give = "you", up = "!");
 @test savename(rick) == "give=you_never=gonna_up=!"
 @test savename(rick; ignores = ["up"]) == "give=you_never=gonna"
+@test savename(rick, sort = false) == "never=gonna_give=you_up=!"
 
 x = 3; y = 5.0;
 d = Dict(:x => x, :y => y)


### PR DESCRIPTION
Sometimes, it's nicer to have names sorted in a particular order with more important parameters at the front. This makes it easier when viewing outputs in a file manager, too. 

Obviously, this only works for types like NamedTuple that are sorted.

