### PR TITLE
added an option to parse parameters as Named Tuple

### DIFF
--- a/src/naming.jl
+++ b/src/naming.jl
@@ -359,10 +359,12 @@ is delimited by `=` and the closest `connector`. This allows the user to have `c
 * `connector = "_"` : string used to connect the various entries.
 * `parsetypes = (Int, Float64)` : tuple used to define the types which should
   be tried when parsing the values given in `filename`. Fallback is `String`.
+* `asnamedtuple = false` : return parsed arguments as `NamedTuple` instead of `Dict`
 """
 function parse_savename(filename::AbstractString;
                         parsetypes = (Int, Float64),
-                        connector::AbstractString = "_")
+                        connector::AbstractString = "_",
+                        asnamedtuple = false)
     length(connector) == 1 || error(
     "Cannot parse savenames where the 'connector'"*
     " string consists of more than one character.")
@@ -423,6 +425,8 @@ function parse_savename(filename::AbstractString;
         "Values containing '$connector' are not allowed when parsing.")
     parameters[_parameters[c_idx:prevind(_parameters,first(equal_sign))]] =
         parse_from_savename_value(parsetypes,_parameters[nextind(_parameters,first(equal_sign)):end])
+
+    parameters = asnamedtuple ? (;map(x -> (Symbol(x[1]), x[2]), collect(parameters))...) : parameters
     return prefix,parameters,suffix
 end
 

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -107,10 +107,17 @@ di = @dict a b c d
 sn = savename(di,scientific=4)
 _,parsed,_ = parse_savename(sn)
 @test parsed["a"] == 1.234e-7
+_,parsed,_ = parse_savename(sn, asnamedtuple = true)
+@test typeof(parsed) <:NamedTuple
+@test parsed.a == 1.234e-7
 
 sn = savename(di,scientific=1)
 _,parsed,_ = parse_savename(sn)
 @test parsed["a"] == 1.0e-7
+
+_,parsed,_ = parse_savename(sn, asnamedtuple = true)
+@test typeof(parsed) <:NamedTuple
+@test parsed.a == 1.0e-7
 
 
 # Test for NaN and Inf compatibility


### PR DESCRIPTION
This is a tiny PR, which adds an option to return parsed parameters in `parse_savename` as NamedTuple. It of course causes type instability, but I do not think it will be devastating in this case.