### PR TITLE
Relax type constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.18.3
+* Remove type constraints on `produce_or_load` path argument (#229)
 # 1.18.2
 * Keyword `storepatch` now exists in `produce_or_load` as well.
 # 1.18.1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.18.2"
+version = "1.18.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -35,8 +35,8 @@ See also [`savename`](@ref).
 """
 produce_or_load(c, f; kwargs...) = produce_or_load("", c, f; kwargs...)
 produce_or_load(f::Function, c; kwargs...) = produce_or_load(c, f; kwargs...)
-produce_or_load(f::Function, path::String, c; kwargs...) = produce_or_load(path, c, f; kwargs...)
-function produce_or_load(path::String, c, f::Function;
+produce_or_load(f::Function, path, c; kwargs...) = produce_or_load(path, c, f; kwargs...)
+function produce_or_load(path, c, f::Function;
     tag::Bool = true, gitpath = projectdir(), loadfile = true,
     suffix = "bson", prefix = default_prefix(c),
     force = false, verbose = true, storepatch = true, kwargs...)


### PR DESCRIPTION
This simple 2-line PR relaxes the type constraints on 
what is accepted as a path.

This adds generic compatibility to custom filepath structures.

closes #229 