### PR TITLE
Rounding and scientific notation in `savename`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.19.0
+* `savename` will no longer replace a floating point number with its integer version, if they coincide with respect to rounding. Thus, "integer" `AbstractFloat`s will always end with `.0` in `savename`.
 # 1.18.3
 * Remove type constraints on `produce_or_load` path argument (#229)
 # 1.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 * `tmpsave` now saves as JLD2.jl and requires loading explicitly the `"params"` field.
 * `collect_results` saves as JLD2.jl by default now.
 * `produce_or_load` saves as JLD2.jl by default now.
-
-# 1.19.0
 * `savename` will no longer replace a floating point number with its integer version, if they coincide with respect to rounding. Thus, "integer" `AbstractFloat`s will always end with `.0` in `savename`.
+* `savename`'s `scientific` keyword has been replaced by `sigdigits`, as this was the only thing it was doing.
+
 # 1.18.3
 * Remove type constraints on `produce_or_load` path argument (#229)
 # 1.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * `produce_or_load` saves as JLD2.jl by default now.
 * `savename` will no longer replace a floating point number with its integer version, if they coincide with respect to rounding. Thus, "integer" `AbstractFloat`s will always end with `.0` in `savename`.
 * `savename`'s `scientific` keyword has been replaced by `sigdigits`, as this was the only thing it was doing.
+* `savename`'s default options now have `sigdigits = 3` instead of `digits = 3`.
+## Non-breaking
+* `savename` now allows a keyword `val_to_string` for customization.
 
 # 1.18.3
 * Remove type constraints on `produce_or_load` path argument (#229)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "1.18.3"
+version = "1.19.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -28,7 +28,7 @@ _wsave(filename, data...; kwargs...) = FileIO.save(filename, data...; kwargs...)
 
 Save `data` at `filename` by first creating the appropriate paths.
 Default fallback is `FileIO.save`. Extend `wsave` for your type
-by extending `DrWatson._wsave`.
+by extending `DrWatson._wsave(filename, data...; kwargs...)`.
 """
 function wsave(filename, data...; kwargs...)
     mkpath(dirname(filename))

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -64,7 +64,8 @@ if they two values coincide. I.e. no longer is `1.0` output as `1` in `savename`
 In this new major release, the following breaking changes have occured:
 1. DrWatson now uses, and suggests using, JLD2.jl instead of BSON.jl
    for saving files.
-2. The `savename` stuff.
+2. The behavior of `savename` with respect to rounding has changed,
+   see its docstring for more.
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -50,8 +50,8 @@ function __init__()
 end
 
 # Update messages
-const display_update = false
-const update_version = "1.8.0"
+const display_update = true
+const update_version = "1.19.0"
 const update_name = "update_v$update_version"
 if display_update
 if !isfile(joinpath(@__DIR__, update_name))
@@ -59,7 +59,8 @@ printstyled(stdout,
 """
 \nUpdate message: DrWatson v$update_version
 
-A cool new feature was added to the `@quickactivate` macro!
+`savename` no longer replaces `AbstractFloat` values with integer values
+if they two values coincide. I.e. no longer is `1.0` output as `1` in `savename`.
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -62,7 +62,7 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
 
 ## Examples
 ```julia
-d = (a = 0.153456453, b = 5.0, mode = "double")
+d = (a = 0.153456453, b = 5, mode = "double")
 savename(d; digits = 4) == "a=0.1535_b=5_mode=double"
 savename("n", d) == "n_a=0.153_b=5_mode=double"
 savename(d, "n") == "a=0.153_b=5_mode=double.n"

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -29,7 +29,15 @@ See [`default_prefix`](@ref) for more.
 [`@dict`](@ref) or [`@ntuple`](@ref).
 See also [`parse_savename`](@ref) and [`@savename`](@ref).
 
-## Keywords
+## Standard keywords
+* `sort = true` : Indicate whether the pairs are sorted alphabetically by
+  keys. If not, they are sorted by the order of `accesses`. WARNING: the
+  default `accesses` is not deterministic for `Dict` inputs.
+* `digits = nothing, sigdigits = 3` : Floating point values are rounded using the `round`
+  function with these keywords.
+* `connector = "_"` : string used to connect the various entries.
+
+## Customization keywords
 * `allowedtypes = default_allowed(c)` : Only values of type subtyping
   anything in `allowedtypes` are used in the name. By default
   this is `(Real, String, Symbol, TimeType)`.
@@ -40,15 +48,9 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   to ignore with the keyword `ignores`. By default this is an empty
   tuple, see [`allignore`](@ref).
   (keys in `ignore` are ignored even if they are in `accesses`)
-* `sort = true` : Indicate whether the pairs are sorted alphabetically by
-  keys. If not, they are sorted by the order of `accesses`. WARNING: the
-  default `accesses` is not deterministic for `Dict` inputs.
-* `digits = 3, sigdigits = nothing` : Floating point values are rounded using the `round`
-  function with these keywords.
 * `val_to_string = nothing` : If not `nothing`, this is a function that converts any given
   value to a string representation, and allows for custom formatting.
   If given, `digits, sigidigits` are ignored.
-* `connector = "_"` : string used to connect the various entries.
 * `expand::Vector{String} = default_expand(c)` : keys that will be expanded
   to the `savename` of their contents, to allow for nested containers.
   By default is empty. Notice that the type of the container must also be
@@ -92,7 +94,7 @@ function savename(prefix::String, c, suffix::String;
         """
     end
     digits = sigdigits === nothing ? digits : nothing
-    val2string === nothing ? (val -> valtostring(val, digits, sigdigits)) : val_to_string
+    val2string = val_to_string === nothing ? (val -> valtostring(val, digits, sigdigits)) : val_to_string
     # Here take care of extra prefix besides default
     dpre = default_prefix(c)
     if dpre != "" && prefix != dpre

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -6,17 +6,15 @@ export tostringdict, tosymboldict
 """
     savename([prefix,], c [, suffix]; kwargs...)
 Create a shorthand name, commonly used for saving a file or as a figure title,
-based on the
-parameters in the container `c` (`Dict`, `NamedTuple` or any other Julia
-composite type). If provided use
-the `prefix` and end the name with `.suffix` (i.e. you don't have to include
-the `.` in your `suffix`).
+based on the parameters in the container `c` (`Dict`, `NamedTuple` or any other Julia
+composite type). If provided use the `prefix` and end the name with `.suffix`
+(i.e. you don't have to include the `.` in your `suffix`).
 
 The function chains keys and values into a string of the form:
 ```julia
 key1=val1_key2=val2_key3=val3
 ```
-while the keys are **sorted alphabetically** by default. If you provide
+while the keys are sorted alphabetically by default. If you provide
 the prefix/suffix the function will do:
 ```julia
 prefix_key1=val1_key2=val2_key3=val3.suffix
@@ -42,20 +40,23 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   to ignore with the keyword `ignores`. By default this is an empty
   tuple, see [`allignore`](@ref).
   (keys in `ignore` are ignored even if they are in `accesses`)
+* `sort = true` : Indicate whether the pairs are sorted alphabetically by
+  keys. If not, they are sorted by the order of `accesses`. WARNING: the
+  default `accesses` is not deterministic for `Dict` inputs.
 * `digits = 3, sigdigits = nothing` : Floating point values are rounded using the `round`
   function with these keywords.
+* `val_to_string = nothing` : If not `nothing`, this is a function that converts any given
+  value to a string representation, and allows for custom formatting.
+  If given, `digits, sigidigits` are ignored.
 * `connector = "_"` : string used to connect the various entries.
 * `expand::Vector{String} = default_expand(c)` : keys that will be expanded
   to the `savename` of their contents, to allow for nested containers.
   By default is empty. Notice that the type of the container must also be
-  allowed in `allowedtypes` for `expand` to take effect! Empty containers
-  are always skipped and the `savename` of the nested arguments is always
+  allowed in `allowedtypes` for `expand` to take effect! The `savename` of
+  the nested arguments is always
   called with its default arguments (so customization here is possible only
-  by rolling your own container type). If the `savename` of the nested
-  containers is `""`, it is also skipped.
-* `sort = true` : Indicate whether the pairs are sorted alphabetically by
-  keys. If not, they are sorted by the order of `accesses`. WARNING: the
-  default `accesses` is not deterministic for `Dict` inputs.
+  by rolling your own container type). Containers leading to empty `savename`
+  are skipped.
 
 ## Examples
 ```julia
@@ -80,6 +81,7 @@ function savename(prefix::String, c, suffix::String;
                   accesses = allaccess(c), ignores = allignore(c), digits = 3,
                   connector = "_", expand::Vector{String} = default_expand(c),
                   sigdigits::Union{Int,Nothing}=nothing,
+                  val_to_string = nothing,
                   sort = true)
 
     if any(sep in prefix for sep in ['/', '\\'])
@@ -90,6 +92,7 @@ function savename(prefix::String, c, suffix::String;
         """
     end
     digits = sigdigits === nothing ? digits : nothing
+    val2string === nothing ? (val -> valtostring(val, digits, sigdigits)) : val_to_string
     # Here take care of extra prefix besides default
     dpre = default_prefix(c)
     if dpre != "" && prefix != dpre
@@ -108,14 +111,13 @@ function savename(prefix::String, c, suffix::String;
         val = access(c, accesses[j])
         t = typeof(val)
         if any(x -> (t <: x), allowedtypes)
-            val = roundval(val, digits,sigdigits)
             if label ∈ expand
                 isempty(val) && continue
                 sname = savename(val; connector=",", digits=digits, sigdigits=sigdigits)
                 isempty(sname) && continue
                 entry = label*"="*'('*sname*')'
             else
-                entry = label*"="*valtostring(val)
+                entry = label*"="*val2string(val)
             end
             !first && (s *= connector)
             s *= entry
@@ -126,17 +128,6 @@ function savename(prefix::String, c, suffix::String;
     return s
 end
 
-function roundval(val::T, digits, sigdigits) where {T}
-    if T <: AbstractFloat
-        if isnan(val) || isinf(val)
-            return val
-        else
-            return round(val; digits=digits, sigdigits=sigdigits)
-        end
-    else
-        return val
-    end
-end
 
 """
     valtostring(val)
@@ -144,8 +135,19 @@ end
 Convert `val` to a string with the smallest possible representation of `val`
 that allows recovering `val` from `valtostring(val)`.
 """
-valtostring(val) = string(val)
-valtostring(val::AbstractFloat) = replace(string(val),".0e"=>"e")
+valtostring(val, digits, sigdigits) = string(val)
+function valtostring(val::AbstractFloat, digits, sigdigits)
+    val = roundval(val, digits, sigdigits)
+    return replace(string(val),".0e"=>"e")
+end
+function roundval(val, digits, sigdigits) where {T}
+    if isnan(val) || isinf(val)
+        return val
+    else
+        return round(val; digits=digits, sigdigits=sigdigits)
+    end
+end
+
 
 """
     allaccess(c)

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -43,14 +43,9 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   tuple, see [`allignore`](@ref).
   (keys in `ignore` are ignored even if they are in `accesses`)
 * `digits = 3` : Floating point values are rounded to `digits`.
-  In addition if the following holds:
-  ```julia
-  round(val; digits = digits) == round(Int, val)
-  ```
-  then the integer value is used in the name instead.
 * `scientific = nothing` : Number of significant digits used for rounding of
   floating point values using scientific notation (e.g. `1.65e-7`).
-  If `nothing`, normal rounding is done.
+  If `nothing`, normal rounding is done, else it overwrites `digits`.
 * `connector = "_"` : string used to connect the various entries.
 * `expand::Vector{String} = default_expand(c)` : keys that will be expanded
   to the `savename` of their contents, to allow for nested containers.
@@ -140,20 +135,18 @@ Round `val`, if roundable, where `digits` defines the number of digits
 and `scientific` the number of significant digits used for rounding.
 `scientific` overwrites `digits`.
 """
-function roundval(val::Tv;digits::Td, scientific::Ts) where {Tv, Td, Ts}
+function roundval(val::Tv; digits::Td, scientific::Ts) where {Tv, Td, Ts}
     if Tv <: AbstractFloat
         if isnan(val) || isinf(val)
             return val
         end
         if Ts <: Int
-            x = round(val,sigdigits = scientific)
+            x = round(val; sigdigits = scientific)
         else
             x = round(val; digits = digits)
         end
-        y = round(Int, val)
-        return val = x == y ? y : x
+        return x
     end
-    return val
 end
 
 """

--- a/test/customize_savename.jl
+++ b/test/customize_savename.jl
@@ -25,20 +25,18 @@ DrWatson.allaccess(::Experiment) = (:n, :c, :x, :species)
 Base.string(::Mouse) = "mouse"
 Base.string(::Cat) = "cat"
 
-
-
-@test savename(e1) == "Experiment_1991-04-13_c=10_n=50_x=0.2"
+@test savename(e1) == "Experiment_1991-04-13_c=10.0_n=50_x=0.2"
 @test savename(e2) == savename(e1)
 
 
 # Add the extra type:
 DrWatson.default_allowed(::Experiment) = (Real, String, Species)
 
-@test savename(e1) ≠ "Experiment_1991-04-13_c=10_n=50_x=0.2"
+@test savename(e1) ≠ "Experiment_1991-04-13_c=10.0_n=50_x=0.2"
 @test savename(e2) ≠ savename(e1)
 
-@test savename(e1) == "Experiment_1991-04-13_c=10_n=50_species=mouse_x=0.2"
-@test savename(e2) == "Experiment_1991-04-13_c=10_n=50_species=cat_x=0.2"
+@test savename(e1) == "Experiment_1991-04-13_c=10.0_n=50_species=mouse_x=0.2"
+@test savename(e2) == "Experiment_1991-04-13_c=10.0_n=50_species=cat_x=0.2"
 
 d = struct2dict(e1)
 @test keytype(d) == Symbol
@@ -56,4 +54,4 @@ end
 s = savename(joinpath("path", "to", "data"), e1)
 @test s[1:4] == "path"
 @test occursin("Experiment", s)
-@test s == joinpath("path", "to", "data", "Experiment_1991-04-13_c=10_n=50_species=mouse_x=0.2")
+@test s == joinpath("path", "to", "data", "Experiment_1991-04-13_c=10.0_n=50_species=mouse_x=0.2")

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -2,7 +2,7 @@ using DrWatson, Test, Dates
 
 ps = DrWatson.PATH_SEPARATOR
 
-d = (a = 0.153456453, b = 5.0, mode = "double")
+d = (a = 0.153456453, b = 5, mode = "double")
 @test savename(d; digits = 4) == "a=0.1535_b=5_mode=double"
 @test savename("n", d) == "n_a=0.153_b=5_mode=double"
 @test savename("n$(ps)", d) == "n$(ps)a=0.153_b=5_mode=double"
@@ -39,8 +39,8 @@ n2 = (x = x, y = y, z = z)
 @test savename(n2; ignores=("y",)) == "x=3_z=lala"
 @test savename(n2; accesses=(:x, :y), ignores=(:y,)) == "x=3"
 
-@test savename(@dict x y) == "x=3_y=5"
-@test savename(@ntuple x y) == "x=3_y=5"
+@test savename(@dict x y) == "x=3_y=5.0"
+@test savename(@ntuple x y) == "x=3_y=5.0"
 w = rand(50)
 @test savename(@dict x y w) == savename(@dict x y)
 @test (@savename x y w) == savename(@dict x y)
@@ -94,24 +94,23 @@ x = A(5, (m = rand(50,50),))
 
 # Scientific notation for savename
 a = 1.2345e-7
-b = 1.0
 c = 1
 d = "test"
-di = @dict a b c d
+di = @dict a c d
 
-@test savename(di,scientific=6) == "a=1.2345e-7_b=1_c=1_d=test"
-@test savename(di,scientific=5) == "a=1.2345e-7_b=1_c=1_d=test"
-@test savename(di,scientific=4) == "a=1.234e-7_b=1_c=1_d=test"
-@test savename(di,scientific=3) == "a=1.23e-7_b=1_c=1_d=test"
-@test savename(di,scientific=2) == "a=1.2e-7_b=1_c=1_d=test"
-@test savename(di,scientific=1) == "a=1e-7_b=1_c=1_d=test"
-@test savename(di) == "a=0_b=1_c=1_d=test"
+@test savename(di,sigdigits=6) == "a=1.2345e-7_c=1_d=test"
+@test savename(di,sigdigits=5) == "a=1.2345e-7_c=1_d=test"
+@test savename(di,sigdigits=4) == "a=1.234e-7_c=1_d=test"
+@test savename(di,sigdigits=3) == "a=1.23e-7_c=1_d=test"
+@test savename(di,sigdigits=2) == "a=1.2e-7_c=1_d=test"
+@test savename(di,sigdigits=1) == "a=1e-7_c=1_d=test"
+@test savename(di) == "a=0.0_c=1_d=test"
 
-sn = savename(di,scientific=4)
+sn = savename(di,sigdigits=4)
 _,parsed,_ = parse_savename(sn)
 @test parsed["a"] == 1.234e-7
 
-sn = savename(di,scientific=1)
+sn = savename(di,sigdigits=1)
 _,parsed,_ = parse_savename(sn)
 @test parsed["a"] == 1.0e-7
 


### PR DESCRIPTION
Closes #163, closes #158

Okay, the hope here is to address all concerns and requests of #163. It also removes the "Float -> Integer" existing convention of `savename`, which in hindsight was a bad idea.

Currently work in progress.