### PR TITLE
Fix loading of results collection with JLD2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,10 +22,11 @@ julia = "1.0"
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "BSON", "Parameters", "DataFrames", "JLD2", "Statistics", "Dates"]
+test = ["Test", "BSON", "FileIO", "Parameters", "DataFrames", "JLD2", "Statistics", "Dates"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -83,7 +83,7 @@ function collect_results!(filename, folder;
         df = DataFrames.DataFrame()
     else
         verbose && @info "Loading existing result collection..."
-        df = wload(filename)[:df]
+        df = wload(filename)["df"]
     end
     @info "Scanning folder $folder for result files."
 
@@ -116,7 +116,7 @@ function collect_results!(filename, folder;
         n += 1
     end
     verbose && @info "Added $n entries."
-    !newfile && wsave(filename, Dict(:df => df))
+    !newfile && wsave(filename, Dict("df" => df))
     return df
 end
 

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -15,7 +15,7 @@ function f(simulation)
     return @strdict a b simulation
 end
 
-@testset "Tagsafe - Filetype: ($ending)" for ending ∈ ["bson", "jld2"]
+@testset "Tagsafe ($ending)" for ending ∈ ["bson", "jld2"]
 ################################################################################
 #                                 tagsave                                      #
 ################################################################################

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -1,4 +1,5 @@
 using DrWatson, Test
+using BSON, JLD2
 cd(@__DIR__)
 T = 1000
 N = 50 # spatial extent
@@ -14,60 +15,62 @@ function f(simulation)
     return @strdict a b simulation
 end
 
-
+@testset "Tagsafe - Filetype: ($ending)" for ending ∈ ["bson", "jld2"]
 ################################################################################
 #                                 tagsave                                      #
 ################################################################################
-t = f(simulation)
-tagsave(savename(simulation, "bson"), t, gitpath=findproject())
-file = load(savename(simulation, "bson"))
-@test "gitcommit" ∈ keys(file)
-@test file["gitcommit"] |> typeof == String
-rm(savename(simulation, "bson"))
+    t = f(simulation)
+    tagsave(savename(simulation, ending), t, gitpath=findproject())
+    file = load(savename(simulation, ending))
+    @test "gitcommit" ∈ keys(file)
+    @test file["gitcommit"] |> typeof == String
+    rm(savename(simulation, ending))
 
-t = f(simulation)
-@tagsave(savename(simulation, "bson"), t, safe=false, gitpath=findproject())
-file = load(savename(simulation, "bson"))
-@test "gitcommit" ∈ keys(file)
-@test file["gitcommit"] |> typeof == String
-@test "script" ∈ keys(file)
-@test file["script"] |> typeof == String
-@test file["script"] == joinpath("test", "savefiles_tests.jl#29")
+    t = f(simulation)
+    @tagsave(savename(simulation, ending), t, safe=false, gitpath=findproject())
+    file = load(savename(simulation, ending))
+    @test "gitcommit" ∈ keys(file)
+    @test file["gitcommit"] |> typeof == String
+    @test "script" ∈ keys(file)
+    @test file["script"] |> typeof == String
+    @test file["script"] == joinpath("test", "savefiles_tests.jl#30")
 
-t = f(simulation)
-@tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())
-sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
-@test isfile(sn)
-rm(sn)
+    t = f(simulation)
+    @tagsave(savename(simulation, ending), t, safe=true, gitpath=findproject())
+    sn = savename(simulation, ending)[1:end-5]*"_#1"*"."*ending
+    @test isfile(sn)
+    rm(sn)
 
-t = f(simulation)
-tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())
-sn = savename(simulation, "bson")[1:end-5]*"_#1"*".bson"
-@test isfile(sn)
-rm(sn)
+    t = f(simulation)
+    tagsave(savename(simulation, ending), t, safe=true, gitpath=findproject())
+    sn = savename(simulation, ending)[1:end-5]*"_#1"*"."*ending
+    @test isfile(sn)
+    rm(sn)
 
-t = f(simulation)
-t["gitcommit"] = ""
-@test @tagsave(savename(simulation, "bson"), t, safe=true, gitpath=findproject())["gitcommit"] == ""
-@test isfile(sn)
-rm(sn)
-@test @tagsave(savename(simulation, "bson"), t, safe=true, force=true, gitpath=findproject())["gitcommit"] != ""
-@test isfile(sn)
-rm(sn)
+    t = f(simulation)
+    t["gitcommit"] = ""
+    @test @tagsave(savename(simulation, ending), t, safe=true, gitpath=findproject())["gitcommit"] == ""
+    @test isfile(sn)
+    rm(sn)
+    @test @tagsave(savename(simulation,ending), t, safe=true, force=true, gitpath=findproject())["gitcommit"] != ""
+    @test isfile(sn)
+    rm(sn)
 
-rm(savename(simulation, "bson"))
-@test !isfile(savename(simulation, "bson"))
+    rm(savename(simulation, ending))
+    @test !isfile(savename(simulation, ending))
 
-ex = @macroexpand @tagsave("testname.bson", (@dict a b c ), storepatch=false; safe=true)
-ex2 = @macroexpand @tagsave("testname.bson", @dict a b c; storepatch=false, safe=true)
-@test ex.args[1:end-1] == ex2.args[1:end-1]
+    ex = @macroexpand @tagsave("testname."*ending, (@dict a b c ), storepatch=false; safe=true)
+    ex2 = @macroexpand @tagsave("testname."*ending, @dict a b c; storepatch=false, safe=true)
+    @test ex.args[1:end-1] == ex2.args[1:end-1]
 
-# Remove leftover
+    # Remove leftover
+end
 
 ################################################################################
 #                              produce or load                                 #
 ################################################################################
-for ending ∈ ("bson", "jld2")
+
+@testset "Produce or Load ($ending)" for ending ∈ ["bson", "jld2"]
     @test !isfile(savename(simulation, ending))
     sim, path = produce_or_load(simulation, f; suffix = ending)
     @test isfile(savename(simulation, ending))
@@ -113,15 +116,18 @@ rm(savename(simulation, "jld2"))
 ################################################################################
 #                          Backup files before saving                          #
 ################################################################################
-filepath = "test.#backup.jld2"
-data = [Dict( "a" => i, "b" => rand(rand(1:10))) for i = 1:3]
-for i = 1:3
-    safesave(filepath, data[i])
-    @test data[i] == load(filepath)
+
+@testset "Backup ($ending)" for ending ∈ ["bson", "jld2"]
+    filepath = "test.#backup."*ending
+    data = [Dict( "a" => i, "b" => rand(rand(1:10))) for i = 1:3]
+    for i = 1:3
+        safesave(filepath, data[i])
+        @test data[i] == load(filepath)
+    end
+    @test data[2] == load("test.#backup_#1."*ending)
+    @test data[1] == load("test.#backup_#2."*ending)
+    @test data[3] == load("test.#backup."*ending)
+    rm("test.#backup."*ending)
+    rm("test.#backup_#1."*ending)
+    rm("test.#backup_#2."*ending)
 end
-@test data[2] == load("test.#backup_#1.jld2")
-@test data[1] == load("test.#backup_#2.jld2")
-@test data[3] == load("test.#backup.jld2")
-rm("test.#backup.jld2")
-rm("test.#backup_#1.jld2")
-rm("test.#backup_#2.jld2")

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -102,7 +102,7 @@ end
 #                           Load and analyze  DataFrame                       #
 ###############################################################################
 
-df = BSON.load(defaultname)[:df]
+df = BSON.load(defaultname)["df"]
 @test size(df) == size(cres2)
 @test sort(names(df)) == sort(names(cres2))
 

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -8,153 +8,148 @@ using BSON, DataFrames, FileIO, JLD2
 #                        Setup Folder structure                               #
 ###############################################################################
 # %%
-    cd(@__DIR__)
-    isdir("testdir") && rm("testdir", recursive=true)
-    mkdir("testdir")
-    initialize_project("testdir"; git = false)
-    quickactivate("testdir")
+cd(@__DIR__)
+isdir("testdir") && rm("testdir", recursive=true)
+mkdir("testdir")
+initialize_project("testdir"; git = false)
+quickactivate("testdir")
 
 ###############################################################################
 #                           Create Dummy Data                                 #
 ###############################################################################
-    mkdir(datadir("results"))
-    cd(datadir("results"))
+mkdir(datadir("results"))
+cd(datadir("results"))
 
-    d = Dict("a" => 1, "b" => "2", "c" => rand(10))
-    DrWatson.wsave(savename(d)*"."*ending, d)
+d = Dict("a" => 1, "b" => "2", "c" => rand(10))
+DrWatson.wsave(savename(d)*"."*ending, d)
 
-    d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
-    DrWatson.wsave(savename(d)*"."*ending, d)
+d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
+DrWatson.wsave(savename(d)*"."*ending, d)
 
-    d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
-    DrWatson.wsave(savename(d)*"."*ending, d)
+d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
+DrWatson.wsave(savename(d)*"."*ending, d)
 
-    mkdir("subfolder")
-    cd("subfolder")
+mkdir("subfolder")
+cd("subfolder")
 
-    d = Dict("a" => 4., "b" => "twenty" , "d" => Int)
-    DrWatson.wsave(savename(d)*"."*ending, d)
+d = Dict("a" => 4., "b" => "twenty" , "d" => Int)
+DrWatson.wsave(savename(d)*"."*ending, d)
 
 ###############################################################################
 #                           Collect Data Into DataFrame                       #
 ###############################################################################
-    using Statistics
-    special_list = [ :lv_mean => data -> mean(data["c"]),
-                    :lv_var  => data -> var(data["c"])]
+using Statistics
+special_list = [ :lv_mean => data -> mean(data["c"]),
+                :lv_var  => data -> var(data["c"])]
 
-    black_list = ["c"]
+black_list = ["c"]
 
-    folder = datadir("results")
+folder = datadir("results")
 
-    defaultname = joinpath(dirname(folder), "results_$(basename(folder))."*ending)
-    isfile(defaultname) && rm(defaultname)
-    cres = collect_results!(defaultname, folder;
-        subfolders = true, special_list=special_list, black_list = black_list)
+defaultname = joinpath(dirname(folder), "results_$(basename(folder))."*ending)
+isfile(defaultname) && rm(defaultname)
+cres = collect_results!(defaultname, folder;
+    subfolders = true, special_list=special_list, black_list = black_list)
 
-    @test size(cres) == (4, 6)
-    for n in ("a", "b", "lv_mean")
-        @test n ∈ String.(names(cres))
-    end
-    @test "c" ∉ names(cres)
-    @test all(startswith.(cres[!,"path"], projectdir()))
+@test size(cres) == (4, 6)
+for n in ("a", "b", "lv_mean")
+    @test n ∈ String.(names(cres))
+end
+@test "c" ∉ names(cres)
+@test all(startswith.(cres[!,"path"], projectdir()))
 
-    relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder))."*ending)
-    cres_relpath = collect_results!(relpathname, folder;
-        subfolders = true, special_list=special_list, black_list = black_list,
-        rpath = projectdir())
-    @info all(startswith.(cres[!,"path"], "data"))
+relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder))."*ending)
+cres_relpath = collect_results!(relpathname, folder;
+    subfolders = true, special_list=special_list, black_list = black_list,
+    rpath = projectdir())
+@info all(startswith.(cres[!,"path"], "data"))
 
 ###############################################################################
 #                           Add another file in a sub sub folder              #
 ###############################################################################
 
-    @test isfile(defaultname)
+@test isfile(defaultname)
 
-    mkdir("subsubfolder")
-    cd("subsubfolder")
-    d = Dict("b" => 35., "d" => Number, "c" => rand(5), "e" => "new_column")
-    DrWatson.wsave(savename(d)*".bson", d)
-    DrWatson.wsave(savename(d)*".jld2", d)
+mkdir("subsubfolder")
+cd("subsubfolder")
+d = Dict("b" => 35., "d" => Number, "c" => rand(5), "e" => "new_column")
+DrWatson.wsave(savename(d)*".bson", d)
+DrWatson.wsave(savename(d)*".jld2", d)
 
-    cres2 = collect_results!(defaultname, folder;
-        subfolders = true, special_list=special_list, black_list = black_list)
+cres2 = collect_results!(defaultname, folder;
+    subfolders = true, special_list=special_list, black_list = black_list)
 
-    @test size(cres2) == (6, 7)
-    @test all(names(cres) .∈ Ref(names(cres2)))
+@test size(cres2) == (6, 7)
+@test all(names(cres) .∈ Ref(names(cres2)))
 
 ###############################################################################
 #               Test additional syntax for special list                       #
 ###############################################################################
 
-    special_list2 = [ :lv_mean => data -> mean(data["c"]),
-                    data -> :lv_var  =>  var(data["c"]),
-                    data -> [:lv_mean2 => mean(data["c"]),
-                            :lv_var2  =>  var(data["c"])]]
-    black_list = ["c"]
+special_list2 = [ :lv_mean => data -> mean(data["c"]),
+                data -> :lv_var  =>  var(data["c"]),
+                data -> [:lv_mean2 => mean(data["c"]),
+                        :lv_var2  =>  var(data["c"])]]
+black_list = ["c"]
 
-    folder = datadir("results")
-    defaultname2 = joinpath(dirname(folder), "results_betterspeciallist."*ending)
-    isfile(defaultname2) && rm(defaultname2)
-    cres10 = collect_results!(defaultname2, folder;
-        subfolders = true, special_list=special_list2, black_list = black_list)
+folder = datadir("results")
+defaultname2 = joinpath(dirname(folder), "results_betterspeciallist."*ending)
+isfile(defaultname2) && rm(defaultname2)
+cres10 = collect_results!(defaultname2, folder;
+    subfolders = true, special_list=special_list2, black_list = black_list)
 
-    @test size(cres10) == (6, 9)
-    for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
-        @test n ∈ String.(names(cres10))
-    end
-    @test "c" ∉ names(cres10)
+@test size(cres10) == (6, 9)
+for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
+    @test n ∈ String.(names(cres10))
+end
+@test "c" ∉ names(cres10)
 ###############################################################################
 #                           Load and analyze  DataFrame                       #
 ###############################################################################
 
-    # if ending == "jld2"
-    #     df = JLD2.load(defaultname)["df"]
-    # elseif ending == "bson"
-    #     df = BSON.load(defaultname)["df"]
-    # end
-    df = load(defaultname)["df"]
-    @test size(df) == size(cres2)
-    @test sort(names(df)) == sort(names(cres2))
+df = load(defaultname)["df"]
+@test size(df) == size(cres2)
+@test sort(names(df)) == sort(names(cres2))
 
 ###############################################################################
 #                            test empty whitelist                             #
 ###############################################################################
 
-    rm(defaultname)
-    cres_empty = collect_results!(defaultname, folder;
-        subfolders = true, special_list=special_list, white_list=[])
+rm(defaultname)
+cres_empty = collect_results!(defaultname, folder;
+    subfolders = true, special_list=special_list, white_list=[])
 
-    @test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
+@test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
 
 ###############################################################################
 #                           test out-of-place form                            #
 ###############################################################################
-    cd(@__DIR__)
+cd(@__DIR__)
 
-    cres3 = collect_results(folder;
-    subfolders = true, special_list=special_list, black_list = black_list)
+cres3 = collect_results(folder;
+subfolders = true, special_list=special_list, black_list = black_list)
 
-    @test sort(names(cres3)) == sort(names(cres2))
-    @test size(cres3) == size(cres2)
+@test sort(names(cres3)) == sort(names(cres2))
+@test size(cres3) == size(cres2)
 
 ###############################################################################
 #                              Quickactivate macro                            #
 ###############################################################################
 
-    cd(@__DIR__)
-    isdir("testdir") && rm("testdir", recursive=true)
-    initialize_project("testdir"; git = false)
-    open(joinpath("testdir","testinclude.jl"),"w") do f
-        write(f,"@quickactivate\n")
-    end
-    include(joinpath("testdir", "testinclude.jl"))
-    @test Base.active_project() == abspath(joinpath("testdir","Project.toml"))
+cd(@__DIR__)
+isdir("testdir") && rm("testdir", recursive=true)
+initialize_project("testdir"; git = false)
+open(joinpath("testdir","testinclude.jl"),"w") do f
+    write(f,"@quickactivate\n")
+end
+include(joinpath("testdir", "testinclude.jl"))
+@test Base.active_project() == abspath(joinpath("testdir","Project.toml"))
 
 ###############################################################################
 #                                 Delete Folders                              #
 ###############################################################################
 
-    cd(@__DIR__)
-    rm("testdir", recursive=true)
+cd(@__DIR__)
+rm("testdir", recursive=true)
 
 end

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -1,148 +1,160 @@
 using DrWatson, Test
-using BSON, DataFrames, JLD2
+using BSON, DataFrames, FileIO, JLD2
+
+
+@testset "Collect Results ($ending)" for ending ∈ ["bson", "jld2"]
+
 ###############################################################################
 #                        Setup Folder structure                               #
 ###############################################################################
 # %%
-cd(@__DIR__)
-isdir("testdir") && rm("testdir", recursive=true)
-mkdir("testdir")
-initialize_project("testdir"; git = false)
-quickactivate("testdir")
+    cd(@__DIR__)
+    isdir("testdir") && rm("testdir", recursive=true)
+    mkdir("testdir")
+    initialize_project("testdir"; git = false)
+    quickactivate("testdir")
 
 ###############################################################################
 #                           Create Dummy Data                                 #
 ###############################################################################
-mkdir(datadir("results"))
-cd(datadir("results"))
+    mkdir(datadir("results"))
+    cd(datadir("results"))
 
-d = Dict("a" => 1, "b" => "2", "c" => rand(10))
-DrWatson.wsave(savename(d)*".bson", d)
+    d = Dict("a" => 1, "b" => "2", "c" => rand(10))
+    DrWatson.wsave(savename(d)*"."*ending, d)
 
-d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
-DrWatson.wsave(savename(d)*".bson", d)
+    d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
+    DrWatson.wsave(savename(d)*"."*ending, d)
 
-d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
-DrWatson.wsave(savename(d)*".jld2", d)
+    d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
+    DrWatson.wsave(savename(d)*"."*ending, d)
 
-mkdir("subfolder")
-cd("subfolder")
+    mkdir("subfolder")
+    cd("subfolder")
 
-d = Dict("a" => 4., "b" => "twenty" , "d" => Int)
-DrWatson.wsave(savename(d)*".bson", d)
+    d = Dict("a" => 4., "b" => "twenty" , "d" => Int)
+    DrWatson.wsave(savename(d)*"."*ending, d)
 
 ###############################################################################
 #                           Collect Data Into DataFrame                       #
 ###############################################################################
-using Statistics
-special_list = [ :lv_mean => data -> mean(data["c"]),
-                 :lv_var  => data -> var(data["c"])]
+    using Statistics
+    special_list = [ :lv_mean => data -> mean(data["c"]),
+                    :lv_var  => data -> var(data["c"])]
 
-black_list = ["c"]
+    black_list = ["c"]
 
-folder = datadir("results")
-defaultname = joinpath(dirname(folder), "results_$(basename(folder)).bson")
-isfile(defaultname) && rm(defaultname)
-cres = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list)
+    folder = datadir("results")
 
-@test size(cres) == (4, 6)
-for n in ("a", "b", "lv_mean")
-    @test n ∈ String.(names(cres))
-end
-@test "c" ∉ names(cres)
-@test all(startswith.(cres[!,"path"], projectdir()))
+    defaultname = joinpath(dirname(folder), "results_$(basename(folder))."*ending)
+    isfile(defaultname) && rm(defaultname)
+    cres = collect_results!(defaultname, folder;
+        subfolders = true, special_list=special_list, black_list = black_list)
 
-relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder)).bson")
-cres_relpath = collect_results!(relpathname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list,
-    rpath = projectdir())
-@info all(startswith.(cres[!,"path"], "data"))
+    @test size(cres) == (4, 6)
+    for n in ("a", "b", "lv_mean")
+        @test n ∈ String.(names(cres))
+    end
+    @test "c" ∉ names(cres)
+    @test all(startswith.(cres[!,"path"], projectdir()))
+
+    relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder))."*ending)
+    cres_relpath = collect_results!(relpathname, folder;
+        subfolders = true, special_list=special_list, black_list = black_list,
+        rpath = projectdir())
+    @info all(startswith.(cres[!,"path"], "data"))
 
 ###############################################################################
 #                           Add another file in a sub sub folder              #
 ###############################################################################
 
-@test isfile(defaultname)
+    @test isfile(defaultname)
 
-mkdir("subsubfolder")
-cd("subsubfolder")
-d = Dict("b" => 35., "d" => Number, "c" => rand(5), "e" => "new_column")
-DrWatson.wsave(savename(d)*".bson", d)
-DrWatson.wsave(savename(d)*".jld2", d)
+    mkdir("subsubfolder")
+    cd("subsubfolder")
+    d = Dict("b" => 35., "d" => Number, "c" => rand(5), "e" => "new_column")
+    DrWatson.wsave(savename(d)*".bson", d)
+    DrWatson.wsave(savename(d)*".jld2", d)
 
-cres2 = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list)
+    cres2 = collect_results!(defaultname, folder;
+        subfolders = true, special_list=special_list, black_list = black_list)
 
-@test size(cres2) == (6, 7)
-@test all(names(cres) .∈ Ref(names(cres2)))
+    @test size(cres2) == (6, 7)
+    @test all(names(cres) .∈ Ref(names(cres2)))
 
 ###############################################################################
 #               Test additional syntax for special list                       #
 ###############################################################################
 
-special_list2 = [ :lv_mean => data -> mean(data["c"]),
-                 data -> :lv_var  =>  var(data["c"]),
-                 data -> [:lv_mean2 => mean(data["c"]),
-                          :lv_var2  =>  var(data["c"])]]
-black_list = ["c"]
+    special_list2 = [ :lv_mean => data -> mean(data["c"]),
+                    data -> :lv_var  =>  var(data["c"]),
+                    data -> [:lv_mean2 => mean(data["c"]),
+                            :lv_var2  =>  var(data["c"])]]
+    black_list = ["c"]
 
-folder = datadir("results")
-defaultname2 = joinpath(dirname(folder), "results_betterspeciallist.bson")
-isfile(defaultname2) && rm(defaultname2)
-cres10 = collect_results!(defaultname2, folder;
-    subfolders = true, special_list=special_list2, black_list = black_list)
+    folder = datadir("results")
+    defaultname2 = joinpath(dirname(folder), "results_betterspeciallist."*ending)
+    isfile(defaultname2) && rm(defaultname2)
+    cres10 = collect_results!(defaultname2, folder;
+        subfolders = true, special_list=special_list2, black_list = black_list)
 
-@test size(cres10) == (6, 9)
-for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
-    @test n ∈ String.(names(cres10))
-end
-@test "c" ∉ names(cres10)
+    @test size(cres10) == (6, 9)
+    for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
+        @test n ∈ String.(names(cres10))
+    end
+    @test "c" ∉ names(cres10)
 ###############################################################################
 #                           Load and analyze  DataFrame                       #
 ###############################################################################
 
-df = BSON.load(defaultname)["df"]
-@test size(df) == size(cres2)
-@test sort(names(df)) == sort(names(cres2))
+    # if ending == "jld2"
+    #     df = JLD2.load(defaultname)["df"]
+    # elseif ending == "bson"
+    #     df = BSON.load(defaultname)["df"]
+    # end
+    df = load(defaultname)["df"]
+    @test size(df) == size(cres2)
+    @test sort(names(df)) == sort(names(cres2))
 
 ###############################################################################
 #                            test empty whitelist                             #
 ###############################################################################
 
-rm(defaultname)
-cres_empty = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, white_list=[])
+    rm(defaultname)
+    cres_empty = collect_results!(defaultname, folder;
+        subfolders = true, special_list=special_list, white_list=[])
 
-@test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
+    @test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
 
 ###############################################################################
 #                           test out-of-place form                            #
 ###############################################################################
-cd(@__DIR__)
+    cd(@__DIR__)
 
-cres3 = collect_results(folder;
-subfolders = true, special_list=special_list, black_list = black_list)
+    cres3 = collect_results(folder;
+    subfolders = true, special_list=special_list, black_list = black_list)
 
-@test sort(names(cres3)) == sort(names(cres2))
-@test size(cres3) == size(cres2)
+    @test sort(names(cres3)) == sort(names(cres2))
+    @test size(cres3) == size(cres2)
 
 ###############################################################################
 #                              Quickactivate macro                            #
 ###############################################################################
 
-cd(@__DIR__)
-isdir("testdir") && rm("testdir", recursive=true)
-initialize_project("testdir"; git = false)
-open(joinpath("testdir","testinclude.jl"),"w") do f
-    write(f,"@quickactivate\n")
-end
-include(joinpath("testdir", "testinclude.jl"))
-@test Base.active_project() == abspath(joinpath("testdir","Project.toml"))
+    cd(@__DIR__)
+    isdir("testdir") && rm("testdir", recursive=true)
+    initialize_project("testdir"; git = false)
+    open(joinpath("testdir","testinclude.jl"),"w") do f
+        write(f,"@quickactivate\n")
+    end
+    include(joinpath("testdir", "testinclude.jl"))
+    @test Base.active_project() == abspath(joinpath("testdir","Project.toml"))
 
 ###############################################################################
 #                                 Delete Folders                              #
 ###############################################################################
 
-cd(@__DIR__)
-rm("testdir", recursive=true)
+    cd(@__DIR__)
+    rm("testdir", recursive=true)
+
+end


### PR DESCRIPTION
`collect_results!` is not working with JLD2 files, as the resulting DataFrame is saved in a Dictionary with Symbol keys. Changing this to a String key should have no impact to users, as the base Dictionary is not returned at all.