### PR TITLE
"dirty"-warning in `gitdescribe` includes `gitpath`

### DIFF
--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -57,7 +57,8 @@ function gitdescribe(gitpath = projectdir())
     suffix = ""
     if LibGit2.isdirty(repo)
         suffix = "_dirty"
-        @warn "The Git repository is dirty! Appending $(suffix) to the commit ID"
+        @warn "The Git repository ('$gitpath') is dirty! "*
+        "Appending $(suffix) to the commit ID."
     end
     # then we return the output of `git describe` or the latest commit hash
     # if no annotated tags are available


### PR DESCRIPTION
I use `tag!` to give me information about several repositories that are part of my project. Hence, it's convenient for me to know which one the warning refers to. I think the warning benefits from this additional information. I also think it isn't too long.

This change is very minor and obviously doesn't break anything (`gitpath` is already being interpolated into another warning in the same method). Hence, I do not bother to change other files and adjust version information or the like.
