### PR TITLE
Add Julia project manager link, fix a broken link in docs

### DIFF
--- a/docs/src/workflow.jl
+++ b/docs/src/workflow.jl
@@ -5,7 +5,7 @@
 # ```
 
 # *Disclaimer: DrWatson assumes basic knowledge of how Julia's
-# project manager works.*
+# [project manager](https://pkgdocs.julialang.org/v1/environments/) works.*
 
 # This example page demonstrates how DrWatson's functions help a typical scientific
 # workflow, as illustrated below:
@@ -81,7 +81,7 @@ projectname()
 # that our scripts run within the context of the project and thus use the correct
 # package versions.
 
-# Second, DrWatson provides the powerful function [`projectdir`](@reF) and its derivatives
+# Second, DrWatson provides the powerful function [`projectdir`](@ref) and its derivatives
 # like `datadir, plotsdir, srcdir`, etc.
 projectdir()
 


### PR DESCRIPTION
New to GitHub contributing, new Julia fan, loved the JuliaCon presentation for DrWatson!
Anyway, looking into using DrWatson and noticed a broken link and though the first line in this doc page could use a link out for other noobs like me. 