### PR TITLE
Yet another kwargs: "equals" in savename

### DIFF
--- a/src/naming.jl
+++ b/src/naming.jl
@@ -60,6 +60,8 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   called with its default arguments (so customization here is possible only
   by rolling your own container type). Containers leading to empty `savename`
   are skipped.
+* `equals = "="` : Connector between name and value. Can be useful to modify for 
+  adding space `" = "`.
 
 ## Examples
 ```julia
@@ -69,6 +71,7 @@ savename("n", d) == "n_a=0.153_b=5_mode=double"
 savename(d, "n") == "a=0.153_b=5_mode=double.n"
 savename("n", d, "n"; connector = "-") == "n-a=0.153-b=5-mode=double.n"
 savename(d, allowedtypes = (String,)) == "mode=double"
+savename(d, connector=" | ", equals=" = ") == "a = 0.153 | b = 5 | mode = double"
 
 rick = (never = "gonna", give = "you", up = "!");
 savename(rick) == "give=you_never=gonna_up=!" # keys are sorted!
@@ -85,7 +88,7 @@ function savename(prefix::String, c, suffix::String;
                   connector = "_", expand::Vector{String} = default_expand(c),
                   sigdigits::Union{Int,Nothing}=nothing,
                   val_to_string = nothing,
-                  sort = true)
+                  sort = true, equals = "=")
 
     if any(sep in prefix for sep in ['/', '\\'])
         @warn """
@@ -116,11 +119,11 @@ function savename(prefix::String, c, suffix::String;
         if any(x -> (t <: x), allowedtypes)
             if label ∈ expand
                 isempty(val) && continue
-                sname = savename(val; connector=",", digits=digits, sigdigits=sigdigits)
+                sname = savename(val; connector=",", digits=digits, sigdigits=sigdigits, equals = equals)
                 isempty(sname) && continue
-                entry = label*"="*'('*sname*')'
+                entry = label*equals*'('*sname*')'
             else
-                entry = label*"="*val2string(val)
+                entry = label*equals*val2string(val)
             end
             !first && (s *= connector)
             s *= entry

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -11,6 +11,8 @@ d = (a = 0.153456453, b = 5, mode = "double")
 @test savename("n", d, "n") == "n_a=0.153_b=5_mode=double.n"
 @test savename("n", d, "n"; connector = "-") == "n-a=0.153-b=5-mode=double.n"
 @test savename(d, allowedtypes = (String,)) == "mode=double"
+@test savename(d, connector=" | ", equals=" = ") == "a = 0.153 | b = 5 | mode = double"
+
 tday = today()
 @test savename(@dict(tday)) == "tday=$(string(tday))"
 


### PR DESCRIPTION
This PR adds a new kwarg to `savename`: `equals`.

The default results in unchanged behaviour `equals = "="`
but it can for example be changed to add spaces.

```
d = (a = 0.153456453, b = 5, mode = "double")
savename(d, connector=" | ", equals=" = ") == "a = 0.153 | b = 5 | mode = double"
```

This would be useful for me because I want to use the 
existing power of `savename` to write e.g. legible logfiles where additional spaces can be useful.