### PR TITLE
Add .gitattributes at project initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ## Non-breaking
 * `savename` now allows a keyword `val_to_string` for customization.
 
+# 1.19.0
+* Projects are initialized with `.gitattributes` by default
 # 1.18.3
 * Remove type constraints on `produce_or_load` path argument (#229)
 # 1.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 ## Non-breaking
 * `savename` now allows a keyword `val_to_string` for customization.
 
-# 1.19.0
-* Projects are initialized with `.gitattributes` by default
 # 1.18.3
 * Remove type constraints on `produce_or_load` path argument (#229)
 # 1.18.2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.0.2"
+version = "2.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.1.0"
+version = "2.0.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/defaults/gitattributes.txt
+++ b/src/defaults/gitattributes.txt
@@ -1,0 +1,221 @@
+# This global .gitattributes file is adhered to via command:
+# git config --global core.attributesfile ~/git-global/.gitattributes_global
+#
+# Use this file on every device where git development is done.
+
+
+###
+### Auto detect text files and perform LF normalization
+###
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+* text=auto
+
+###
+### The above will handle all files NOT found below.
+### From https://github.com/alexkaratarakis/gitattributes
+###
+
+### gitattributes/C++.gitattributes d3b93d4 on Jun 20, 2018
+#sources
+*.c text diff=cpp
+*.cc text diff=cpp
+*.cxx text diff=cpp
+*.cpp text diff=cpp
+*.c++ text diff=cpp
+*.hpp text diff=cpp
+*.h text diff=cpp
+*.h++ text diff=cpp
+*.hh text diff=cpp
+
+# Compiled Object files
+*.slo binary
+*.lo binary
+*.o binary
+*.obj binary
+
+# Precompiled Headers
+*.gch binary
+*.pch binary
+
+# Compiled Dynamic libraries
+*.so binary
+*.dylib binary
+*.dll binary
+
+# Compiled Static libraries
+*.lai binary
+*.la binary
+*.a binary
+*.lib binary
+
+# Executables
+*.exe binary
+*.out binary
+*.app binary      
+
+# Other
+##############
+*.exe		binary
+*.num		binary
+*.xls   binary
+*.xlsx  binary
+*.XLS   binary
+*.XLSX  binary
+bin/	binary
+
+### gitattributes/Common.gitattributes 9b38185 on Jun 9, 2018
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain
+*.md text diff=markdown
+*.adoc text
+*.textile text
+*.tex 	text diff=tex
+*.mustache text
+*.csv text
+*.tab text
+*.tsv text
+*.sql text
+
+# Graphics
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.tif binary
+*.tiff binary
+*.ico binary
+# SVG treated as an asset (binary) by default. If you want to treat it as text,
+# comment-out the following line and uncomment the line after.
+*.svg binary
+#*.svg text
+*.eps binary       
+
+### gitattributes/Java.gitattributes c08b42f on Mar 29, 2017
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text
+*.df            text
+*.htm           text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.jsp           text
+*.jspf          text
+*.jspx          text
+*.properties    text
+*.sh            text
+*.tld           text
+*.txt           text
+*.tag           text
+*.tagx          text
+*.xml           text
+*.yml           text
+*.toml			text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.gif           binary
+*.ico           binary
+*.jar           binary
+*.jpg           binary
+*.jpeg          binary
+*.png           binary
+*.so            binary
+*.war binary      
+
+### gitattributes/Matlab.gitattributes d2539f6 on Dec 3, 2015
+# Basic .gitattributes for a MATLAB repo.
+# This template includes Simulink and MuPAD extensions, in addition
+# to the MATLAB extensions.
+
+# Source files
+# ============
+*.m             text
+*.mu            text
+
+# Caution: *.m also matches Mathematica packages.
+
+# Binary files
+# ============
+*.p             binary
+*.mex*          binary
+*.fig           binary
+*.mat           binary
+*.mdl           binary
+*.slx           binary
+*.mdlp          binary
+*.slxp          binary
+*.sldd          binary
+*.mltbx         binary
+*.mlappinstall  binary
+*.mlpkginstall  binary
+*.mn binary      
+
+### gitattributes/Python.gitattributes cbd3af4 on Jun 20, 2018
+# Basic .gitattributes for a python repo.
+
+# Source files
+# ============
+*.pxd		text diff=python
+*.py 		text diff=python
+*.py3 		text diff=python
+*.pyw 		text diff=python
+*.pyx  		text diff=python
+
+# Binary files
+# ============
+*.db		binary
+*.p 		binary
+*.pkl 		binary
+*.pyc 		binary
+*.pyd		binary
+*.pyo 		binary
+
+# Note: .db, .p, and .pkl files are associated
+# with the python modules ``pickle``, ``dbm.*``,
+# ``shelve``, ``marshal``, ``anydbm``, & ``bsddb``
+# (among others).      
+
+### gitattributes/R.gitattributes 80aacc1 on Aug 22, 2015
+# Basic .gitattributes for a R repo.
+
+# Source files
+# ============
+*.Rdata     text
+*.rdb       binary
+*.rds       binary
+*.Rd        text
+*.Rdx       binary
+*.Rmd		text
+*.R text
+      
+

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -315,6 +315,14 @@ function initialize_project(path, name = default_name_from_path(path);
     write(joinpath(path, "scripts", "intro.jl"), makeintro(name))
 
     files = vcat(".gitignore", joinpath("scripts", "intro.jl"), joinpath("test", "runtests.jl"))
+            
+    cp(joinpath(@__DIR__, "defaults", "gitattributes.txt"), joinpath(path, ".gitattributes"))
+    chmod(joinpath(path, ".gitattributes"),0o644)
+
+    write(joinpath(path, "scripts", "intro.jl"), makeintro(name))
+
+    files = vcat(".gitattributes", joinpath("scripts", "intro.jl"), joinpath("test", "runtests.jl"))
+            
     if readme
         write(joinpath(path, "README.md"), DEFAULT_README(name, authors))
         push!(files, "README.md")


### PR DESCRIPTION
Improve cross-platform compatibility and robust handling of binaries, etc with git using .gitattributes.