### PR TITLE
Allow templates in `initialize_project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.1.0
+* `initialize_project` now allows for custom templates.
 # 2.0.4
 * `produce_or_load` now will not attempt to `tagsave` for inappropriate file formats, like `.csv`.
 # 2.0.3

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.0.5"
+version = "2.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -201,7 +201,7 @@ The new project remains activated for you to immidiately add packages.
   is `true` then recursively delete everything in the path and create the project.
 * `git = true` : Make the project a Git repository.
 * `template = DrWatson.DEFAULT_TEMPLATE` : A template containing the folder structure
-  of the project. It should be a vector containing strings (folder) or pairs of `String
+  of the project. It should be a vector containing strings (folders) or pairs of `String
   => Vector{String}`, containg a folder and subfolders (this can be nested further). Example:
   ```
   DEFAULT_TEMPLATE = [
@@ -214,10 +214,11 @@ The new project remains activated for you to immidiately add packages.
     "data" => ["sims", "exp_raw", "exp_pro"],
   ]
   ```
+  Obviously, the default derivative functions of [`projectdir`](@ref), such as `datadir`,
+  have been written with the default template in mind.
 * `placeholder = false` : Add hidden place holder files in each default folder to ensure 
   that project folder structure is maintained when the directory is cloned.
-  Should be used only when `git = true`.
-  Will throw a warning if used with `git = false`
+  Only used when `git = true`.
 """
 function initialize_project(path, name = default_name_from_path(path);
         force = false, readme = true, authors = nothing,
@@ -395,6 +396,15 @@ const DEFAULT_TEMPLATE = [
     "data" => ["sims", "exp_raw", "exp_pro"],
 ]
 
+const DOCUMENTS_TEMPLATE = [
+    "src", 
+    "scripts",
+    "plots", 
+    "notebooks",
+    "documents",
+    "papers",
+    "data" => ["sims", "obs", "ana"], # simulations, observations, analysis
+]
 
 
 ##########################################################################################

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -320,7 +320,6 @@ end
 function compat_entry()
     DrWatson_VERSION = let
         project = joinpath(dirname(dirname(pathof(DrWatson))), "Project.toml")
-        toml = read(project, String)
         versionline = readlines(project)[4]
         VersionNumber(versionline[12:end-1])
     end

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -200,8 +200,23 @@ The new project remains activated for you to immidiately add packages.
 * `force = false` : If the `path` is _not_ empty then throw an error. If however `force`
   is `true` then recursively delete everything in the path and create the project.
 * `git = true` : Make the project a Git repository.
-* `placeholder = false` : Add hidden place holder files in each default folder to ensure that project
-  is maintained when the directory is cloned. Should be used only when `git = true`.
+* `template = DrWatson.DEFAULT_TEMPLATE` : A template containing the folder structure
+  of the project. It should be a vector containing strings (folder) or pairs of `String
+  => Vector{String}`, containg a folder and a subfolder. For example:
+  ```
+  DEFAULT_TEMPLATE = [
+    "_research", 
+    "src", 
+    "scripts",
+    "plots", 
+    "notebooks",
+    "papers",
+    "data" => ["sims", "exp_raw", "exp_pro"],
+  ]
+  ```
+* `placeholder = false` : Add hidden place holder files in each default folder to ensure 
+  that project folder structure is maintained when the directory is cloned.
+  Should be used only when `git = true`.
   Will throw a warning if used with `git = false`
 """
 function initialize_project(path, name = default_name_from_path(path);
@@ -209,9 +224,7 @@ function initialize_project(path, name = default_name_from_path(path);
         git = true, placeholder = false, template = DEFAULT_TEMPLATE
     )
 
-    placeholder && !git && @warn "The placeholder files are created, but you need to "*
-    "manually commit them to your version control software OR initialize project with git = true"
-
+    if git == false; placeholder = false; end
     mkpath(path)
     rd = readdir(path)
     if length(rd) != 0
@@ -257,7 +270,7 @@ function initialize_project(path, name = default_name_from_path(path);
     chmod(joinpath(path, ".gitattributes"), 0o644)
     write(joinpath(path, "intro.jl"), makeintro(name))
 
-    files = [".gitignore", joinpath(path, "intro.jl")]
+    files = [".gitignore", "intro.jl"]
     if readme
         write(joinpath(path, "README.md"), DEFAULT_README(name, authors))
         push!(files, "README.md")
@@ -381,23 +394,21 @@ const DEFAULT_TEMPLATE = [
 # Introductory file
 ##########################################################################################
 function makeintro(name)
-    f = """
+    """
     using DrWatson
     @quickactivate "$name"
-    DrWatson.greet()
-    """
-end
+    
+    println(
+    \"\"\"
+    Currently active project is: \$(projectname())
 
-function greet(name = projectname())
-    s =
-    """
-    Currently active project is: $(name)
+    Path of active project: \$(projectdir())
 
     Have fun with your new project!
 
     You can help us improve DrWatson by opening
     issues on GitHub, submitting feature requests,
     or even opening your own Pull Requests!
+    \"\"\"
     """
-    println(s)
 end

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -185,60 +185,6 @@ end
 ##########################################################################################
 export initialize_project
 
-const DEFAULT_PATHS = [
-"_research", "src", "scripts",
-"plots", "notebooks",
-"papers",
-joinpath("data", "sims"),
-joinpath("data", "exp_raw"),
-joinpath("data", "exp_pro"),
-]
-const PLACEHOLDER_TEXT = """
-This file acts as a placeholder to ensure the project structure is copied whenever you clone the project.
-This doesn't commit any files within the folder.
-"""
-
-function DEFAULT_README(name, authors = nothing)
-    s = """
-    # $name
-
-    This code base is using the Julia Language and [DrWatson](https://juliadynamics.github.io/DrWatson.jl/stable/)
-    to make a reproducible scientific project named
-    > $name
-
-    """
-    if !(authors === nothing)
-        s *= "It is authored by "*join(vecstring(authors), ", ")*".\n\n"
-    end
-
-    s *= """
-    To (locally) reproduce this project, do the following:
-
-    0. Download this code base. Notice that raw data are typically not included in the
-       git-history and may need to be downloaded independently.
-    1. Open a Julia console and do:
-       ```
-       julia> using Pkg
-       julia> Pkg.add("DrWatson") # install globally, for using `quickactivate`
-       julia> Pkg.activate("path/to/this/project")
-       julia> Pkg.instantiate()
-       ```
-
-    This will install all necessary packages for you to be able to run the scripts and
-    everything should work out of the box.
-    """
-    return s
-end
-
-function default_name_from_path(path)
-    ap = abspath(path)
-    path, dir = splitdir(ap)
-    if length(dir) == 0
-        _, dir = splitdir(path)
-    end
-    return dir
-end
-
 """
     initialize_project(path [, name]; kwargs...)
 Initialize a scientific project expected by `DrWatson` in `path` (directory representing
@@ -259,8 +205,9 @@ The new project remains activated for you to immidiately add packages.
   Will throw a warning if used with `git = false`
 """
 function initialize_project(path, name = default_name_from_path(path);
-    force = false, readme = true, authors = nothing,
-    git = true, placeholder = false)
+        force = false, readme = true, authors = nothing,
+        git = true, placeholder = false, template = DEFAULT_TEMPLATE
+    )
 
     placeholder && !git && @warn "The placeholder files are created, but you need to "*
     "manually commit them to your version control software OR initialize project with git = true"
@@ -349,6 +296,69 @@ vecstring(a::String) = [a]
 vecstring(a::Vector{String}) = a
 vecstring(c) = [string(a) for a in c]
 
+
+function default_name_from_path(path)
+    ap = abspath(path)
+    path, dir = splitdir(ap)
+    if length(dir) == 0
+        _, dir = splitdir(path)
+    end
+    return dir
+end
+
+
+const PLACEHOLDER_TEXT = """
+This file acts as a placeholder to ensure the project structure is copied whenever you clone the project.
+This doesn't commit any files within the folder.
+"""
+
+function DEFAULT_README(name, authors = nothing)
+    s = """
+    # $name
+
+    This code base is using the Julia Language and [DrWatson](https://juliadynamics.github.io/DrWatson.jl/stable/)
+    to make a reproducible scientific project named
+    > $name
+
+    """
+    if !(authors === nothing)
+        s *= "It is authored by "*join(vecstring(authors), ", ")*".\n\n"
+    end
+
+    s *= """
+    To (locally) reproduce this project, do the following:
+
+    0. Download this code base. Notice that raw data are typically not included in the
+       git-history and may need to be downloaded independently.
+    1. Open a Julia console and do:
+       ```
+       julia> using Pkg
+       julia> Pkg.add("DrWatson") # install globally, for using `quickactivate`
+       julia> Pkg.activate("path/to/this/project")
+       julia> Pkg.instantiate()
+       ```
+
+    This will install all necessary packages for you to be able to run the scripts and
+    everything should work out of the box, including correctly finding local paths.
+    """
+    return s
+end
+
+##########################################################################################
+# Project templates
+##########################################################################################
+const DEFAULT_TEMPLATE = [
+    "_research", 
+    "src", 
+    "scripts",
+    "plots", 
+    "notebooks",
+    "papers",
+    "data" => ["sims", "exp_raw", "exp_pro"],
+]
+
+
+
 ##########################################################################################
 # Introductory file
 ##########################################################################################
@@ -360,10 +370,10 @@ function makeintro(name)
     """
 end
 
-function greet()
+function greet(name = projectname())
     s =
     """
-    Currently active project is: $(projectname())
+    Currently active project is: $(name)
 
     Have fun with your new project!
 

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -280,10 +280,7 @@ function initialize_project(path, name = default_name_from_path(path);
     if !(authors === nothing)
         w *= "authors = "*sprint(show, vecstring(authors))*"\n"
     end
-    w *= """
-        [compat]
-        julia = "$(VERSION.major).$(VERSION.minor).$(VERSION.patch)"
-        """
+    w *= compat_entry()
     write(joinpath(path, "Project.toml"), w, pro)
     push!(files, "Project.toml")
     git && LibGit2.add!(repo, files...)
@@ -320,7 +317,19 @@ function _recursive_folder_insertion!(path, p::Pair{String, String}, placeholder
     _recursive_folder_insertion!(path, p[2], placeholder, folders, ph_files)
 end
 
-
+function compat_entry()
+    DrWatson_VERSION = let
+        project = joinpath(dirname(dirname(pathof(DrWatson))), "Project.toml")
+        toml = read(project, String)
+        versionline = readlines(project)[4]
+        VersionNumber(versionline[12:end-1])
+    end
+    """
+    [compat]
+    julia = "$(VERSION.major).$(VERSION.minor).$(VERSION.patch)"
+    DrWatson = "$(DrWatson_VERSION)"
+    """
+end
 
 vecstring(a::String) = [a]
 vecstring(a::Vector{String}) = a

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -202,7 +202,7 @@ The new project remains activated for you to immidiately add packages.
 * `git = true` : Make the project a Git repository.
 * `template = DrWatson.DEFAULT_TEMPLATE` : A template containing the folder structure
   of the project. It should be a vector containing strings (folder) or pairs of `String
-  => Vector{String}`, containg a folder and a subfolder. For example:
+  => Vector{String}`, containg a folder and subfolders (this can be nested further). Example:
   ```
   DEFAULT_TEMPLATE = [
     "_research", 
@@ -270,7 +270,7 @@ function initialize_project(path, name = default_name_from_path(path);
     chmod(joinpath(path, ".gitattributes"), 0o644)
     write(joinpath(path, "intro.jl"), makeintro(name))
 
-    files = [".gitignore", "intro.jl"]
+    files = [".gitignore", ".gitattributes", "intro.jl"]
     if readme
         write(joinpath(path, "README.md"), DEFAULT_README(name, authors))
         push!(files, "README.md")
@@ -286,7 +286,6 @@ function initialize_project(path, name = default_name_from_path(path);
         """
     write(joinpath(path, "Project.toml"), w, pro)
     push!(files, "Project.toml")
-
     git && LibGit2.add!(repo, files...)
     git && LibGit2.commit(repo, "File setup by DrWatson")
     return path
@@ -410,5 +409,6 @@ function makeintro(name)
     issues on GitHub, submitting feature requests,
     or even opening your own Pull Requests!
     \"\"\"
+    )
     """
 end

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -54,7 +54,7 @@ com = gitdescribe(path)
 @test ispath(joinpath(path, "data", "exp_raw"))
 z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"George\", \"Nick\"]", z)
-z = read(joinpath(path, "scripts", "intro.jl"), String)
+z = read(joinpath(path, "intro.jl"), String)
 @test occursin("@quickactivate", z)
 
 initialize_project(path, name; force = true, authors = "Sophia", git = false)
@@ -63,7 +63,7 @@ z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"Sophia\"]", z)
 
 # here we test quickactivate
-quickactivate(joinpath(homedir(), path))
+quickactivate(path)
 @test projectname() == name
 
 cd(path)

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -30,7 +30,7 @@ end
 @test uperm(joinpath(path, ".gitignore")) == 0x06
 @test isfile(joinpath(path, "README.md"))
 @test isfile(joinpath(path, "Project.toml"))
-@test uperm(joinpath(path, "scripts", "intro.jl")) == 0x06
+@test uperm(joinpath(path, "intro.jl")) == 0x06
 
 for dir_type in ("data", "src", "plots", "papers", "scripts")
     fn = Symbol(dir_type * "dir")
@@ -74,3 +74,12 @@ cd()
 
 rm(path, recursive = true, force = true)
 @test !isdir(path)
+
+# Test templates
+t1 = ["data", "documents" => ["a", "b"]]
+initialize_project(path, name; force = true, git = false, template = t1)
+
+@test ispath(joinpath(path, "data"))
+@test ispath(joinpath(path, "documents"))
+@test ispath(joinpath(path, "documents", "a"))
+@test !ispath(joinpath(path, "src"))

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -2,7 +2,7 @@ using Pkg, Test, DrWatson
 using LibGit2
 LibGit2.default_signature() = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time(), 0), 0)
 
-cd() # changes directory to `homedir()`
+cd(@__DIR__)
 path = "test project"
 name = "lala"
 
@@ -21,9 +21,8 @@ end
 
 @test projectname() == path
 @test typeof(findproject(@__DIR__)) == String
-for p in DrWatson.DEFAULT_PATHS
-    @test ispath(joinpath(path, p))
-end
+@test ispath(joinpath(path, "src"))
+@test ispath(joinpath(path, "data", "exp_raw"))
 
 @test ispath(projectdir("data"))
 @test isfile(joinpath(path, ".gitignore"))
@@ -72,9 +71,6 @@ cd(path)
 @test findproject(pwd()) == pwd()
 cd()
 
-rm(path, recursive = true, force = true)
-@test !isdir(path)
-
 # Test templates
 t1 = ["data", "documents" => ["a", "b"]]
 initialize_project(path, name; force = true, git = false, template = t1)
@@ -83,3 +79,6 @@ initialize_project(path, name; force = true, git = false, template = t1)
 @test ispath(joinpath(path, "documents"))
 @test ispath(joinpath(path, "documents", "a"))
 @test !ispath(joinpath(path, "src"))
+
+rm(path, recursive = true, force = true)
+@test !isdir(path)

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -50,9 +50,8 @@ com = gitdescribe(path)
 @test !occursin('-', com) # no dashes = no git describe
 
 @test projectname() == name
-for p in DrWatson.DEFAULT_PATHS
-    @test ispath(joinpath(path, p))
-end
+@test ispath(joinpath(path, "src"))
+@test ispath(joinpath(path, "data", "exp_raw"))
 z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"George\", \"Nick\"]", z)
 z = read(joinpath(path, "scripts", "intro.jl"), String)

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -62,6 +62,10 @@ initialize_project(path, name; force = true, authors = "Sophia", git = false)
 z = read(joinpath(path, "Project.toml"), String)
 @test occursin("[\"Sophia\"]", z)
 
+# test whether a DrWatson version is added to compat
+@test occursin("DrWatson =", z)
+
+
 # here we test quickactivate
 quickactivate(path)
 @test projectname() == name

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -31,9 +31,6 @@ end
 # Tag kw-functions
 
 d = Dict(:x => 3, :y => 4)
-d_new = tag!(d)
-
-@test d == d_new
 
 d_new = tag!(d,gitpath=@__DIR__,source="foo")
 @test endswith(d_new[:script],"foo")


### PR DESCRIPTION
Closes #264

Okay, the idea is pretty simple. A template is just a vector of strings or pair=>vector{string}. Seems pretty clean to me, easy to adopt, easy to change. 

Any ideas/recommendations for a couple more pre-made templates are welcomed. 