### PR TITLE
Update the reference to Bibliography.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -119,7 +119,7 @@ or use the DOI directly:
 * <https://github.com/miguelraz/DoctorDocstrings.jl> 
 
 ### Paper-related
-* <https://github.com/Azzaare/Bibliography.jl>
+* <https://github.com/Humans-of-Julia/Bibliography.jl>
 * <https://github.com/SebastianM-C/PkgCite.jl>
 
 ### Writing and debugging code


### PR DESCRIPTION
Bibliography.jl moved to Humans-of-Julia GitHub org a few months ago! Thanks for the reference by the way :)