### PR TITLE
Fix crash of `produce_or_load` when saving file fails.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -65,7 +65,7 @@ function produce_or_load(path, c, f::Function;
             end
             verbose && @info "File $s saved."
         catch er
-            @warn "Could not save file. Error stacktrace:"*
+            @warn "Could not save file. Error stacktrace:"
             Base.showerror(stderr, er, stacktrace(catch_backtrace()))
         end
         if loadfile


### PR DESCRIPTION
Hi,
I noticed that `produce_or_load` crashes when file saving fails, because of a lonely `*`. This fixes the issue.