### PR TITLE
Fix variable name in `findproject`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.1.2"
+version = "2.1.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -58,8 +58,8 @@ _projectname(::Nothing) = nothing
 
 
 """
-    findproject(path = pwd()) -> project_path
-Recursively search `path` and its parents for a valid Julia project file
+    findproject(dir = pwd()) -> project_path
+Recursively search `dir` and its parents for a valid Julia project file
 (anything in `Base.project_names`).
 If it is found return its path, otherwise issue a warning and return
 `nothing`.
@@ -82,7 +82,7 @@ function findproject(dir::AbstractString = pwd())
         dir == old && break
     end
     @warn "DrWatson could not find find a project file by recursively checking "*
-    "given `path` and its parents. Returning `nothing` instead.\n(given path: $path)"
+    "given `dir` and its parents. Returning `nothing` instead.\n(given dir: $dir)"
     return nothing
 end
 


### PR DESCRIPTION
If `findproject` doesn't find its requested directory, it tries to issue a warning, but fails because the input variable name was evidently changed from `path` to `dir`.   This fixes it in the warning and the docstring.