### PR TITLE
Fall back on global git config

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -256,8 +256,10 @@ function initialize_project(path, name = default_name_from_path(path);
     if git
         repo = LibGit2.init(path)
         gc = LibGit2.GitConfig(repo)
-        LibGit2.get(gc, "user.name", false) || LibGit2.set!(gc, "user.name", "DrWatson")
-        LibGit2.get(gc, "user.email", false) || LibGit2.set!(gc, "user.email", "no@mail")
+        LibGit2.get(gc, "user.name", LibGit2.getconfig("user.name", false)) ||
+            LibGit2.set!(gc, "user.name", "DrWatson")
+        LibGit2.get(gc, "user.email", LibGit2.getconfig("user.email", false)) ||
+            LibGit2.set!(gc, "user.email", "no@mail")
         LibGit2.commit(repo, "Initial commit")
     end
 


### PR DESCRIPTION
Currently, with the default parameters, `initialize_project` makes the project a git repo.  As part of that process, it checks the git config *of the repo* for the options `user.name` and `user.email`.  Unless the repo existed already and had those options set explicitly, these options will not exist, so `initialize_project` just sets them to `"DrWatson"` and `"no@mail"`, respectively.  I'm guessing that the reason for this is to ensure that it can make an initial commit without any issues.

That makes some sense, but I think it makes more sense to check the global config before setting those options.  If they exist in the global config (or already in the local config), they shouldn't be set locally.  The initial commit should still work just fine, using those global settings.