### PR TITLE
Allow keyword pass through to wsave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.3.0
+* Enable pass through of kwargs to `wsave` in `produce_or_load`, `tagsave` and `safesave` (to e.g. allow compression in JLD2 files).
 # 2.2.0
 * `isdirty(gitpath = projectdir())` function for checking if `gitpath` points to a dirty Git repository. (#263)
 # 2.1.0

--- a/Project.toml
+++ b/Project.toml
@@ -30,9 +30,10 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 
 [targets]
 test = [
     "Test", "BSON", "FileIO", "Parameters", "DataFrames",
-    "JLD2", "Statistics", "Dates", "CSVFiles"
+    "JLD2", "Statistics", "Dates", "CSVFiles", "CodecZlib"
 ]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -62,7 +62,7 @@ function produce_or_load(path, c, f::Function;
         file = f(c)
         try
             if tag
-                tagsave(s, file; safe = false, gitpath = gitpath, storepatch = storepatch; wsave_kwargs...)
+                tagsave(s, file; safe = false, gitpath = gitpath, storepatch = storepatch, wsave_kwargs...)
             else
                 wsave(s, copy(file); wsave_kwargs...)
             end

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -33,7 +33,8 @@ end
   `nothing, s`, regardless of whether the file exists or not. If it doesn't
   exist it is still produced and saved.
 * `verbose = true` : print info about the process, if the file doesn't exist.
-* `wsave_kwargs = Dict()` : Keywords to pass to wsave (e.g. compression).
+* `wsave_kwargs = Dict()` : Keywords to pass to `wsave` (e.g. to enable
+  compression).
 * `kwargs...` : All other keywords are propagated to `savename`.
 """
 produce_or_load(c, f; kwargs...) = produce_or_load("", c, f; kwargs...)
@@ -93,6 +94,9 @@ Git. If the Git repository is dirty, one more field `:gitpatch` is
 added that stores the difference string.  If a dictionary already
 contains a key `:gitcommit`, it is not overwritten, unless,
 `force=true`. For more details, see [`tag!`](@ref).
+
+Any additional keyword arguments are propagated to `wsave`, to e.g.
+enable compression.
 """
 function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, force = false, source = nothing, kwargs...)
     d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, force=force, source=source)
@@ -110,7 +114,6 @@ end
 Same as [`tagsave`](@ref) but one more field `:script` is added that records
 the local path of the script and line number that called `@tagsave`, see [`@tag!`](@ref).
 """
-# ADD kwargs passthrough to wsave!!
 macro tagsave(file,d,args...)
     args = Any[args...]
     # Keywords added after a ; are moved to the front of the expression

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -33,6 +33,7 @@ end
   `nothing, s`, regardless of whether the file exists or not. If it doesn't
   exist it is still produced and saved.
 * `verbose = true` : print info about the process, if the file doesn't exist.
+* `wsave_kwargs = Dict()` : Keywords to pass to wsave (e.g. compression).
 * `kwargs...` : All other keywords are propagated to `savename`.
 """
 produce_or_load(c, f; kwargs...) = produce_or_load("", c, f; kwargs...)
@@ -41,7 +42,7 @@ produce_or_load(f::Function, path, c; kwargs...) = produce_or_load(path, c, f; k
 function produce_or_load(path, c, f::Function;
     suffix = "jld2", prefix = default_prefix(c),
     tag::Bool = istaggable(suffix), gitpath = projectdir(), loadfile = true,
-    force = false, verbose = true, storepatch = true, kwargs...)
+    force = false, verbose = true, storepatch = true, wsave_kwargs = Dict(), kwargs...)
 
     s = joinpath(path, savename(prefix, c, suffix; kwargs...))
 
@@ -61,9 +62,9 @@ function produce_or_load(path, c, f::Function;
         file = f(c)
         try
             if tag
-                tagsave(s, file; safe = false, gitpath = gitpath, storepatch = storepatch)
+                tagsave(s, file; safe = false, gitpath = gitpath, storepatch = storepatch; wsave_kwargs...)
             else
-                wsave(s, copy(file))
+                wsave(s, copy(file); wsave_kwargs...)
             end
             verbose && @info "File $s saved."
         catch er
@@ -82,7 +83,7 @@ end
 #                             tag saving                                       #
 ################################################################################
 """
-    tagsave(file::String, d::Dict; safe = false, gitpath = projectdir(), storepatch = true, force = false)
+    tagsave(file::String, d::Dict; safe = false, gitpath = projectdir(), storepatch = true, force = false, kwargs...)
 First [`tag!`](@ref) dictionary `d` and then save `d` in `file`.
 If `safe = true` save the file using [`safesave`](@ref).
 
@@ -93,12 +94,12 @@ added that stores the difference string.  If a dictionary already
 contains a key `:gitcommit`, it is not overwritten, unless,
 `force=true`. For more details, see [`tag!`](@ref).
 """
-function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, force = false, source = nothing)
+function tagsave(file, d; safe::Bool = false, gitpath = projectdir(), storepatch = true, force = false, source = nothing, kwargs...)
     d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, force=force, source=source)
     if safe
-        safesave(file, copy(d2))
+        safesave(file, copy(d2); kwargs...)
     else
-        wsave(file, copy(d2))
+        wsave(file, copy(d2); kwargs...)
     end
     return d2
 end
@@ -109,6 +110,7 @@ end
 Same as [`tagsave`](@ref) but one more field `:script` is added that records
 the local path of the script and line number that called `@tagsave`, see [`@tag!`](@ref).
 """
+# ADD kwargs passthrough to wsave!!
 macro tagsave(file,d,args...)
     args = Any[args...]
     # Keywords added after a ; are moved to the front of the expression
@@ -131,7 +133,7 @@ end
 
 # Implementation inspired by behavior of GROMACS
 """
-    safesave(filename, data)
+    safesave(filename, data; kwargs...)
 
 Safely save `data` in `filename` by ensuring that no existing files
 are overwritten. Do this by renaming already existing data with a backup-number
@@ -146,11 +148,14 @@ will rename the old `test_#1.jld2` to `test_#2.jld2`, rename the old
 `test.jld2` to `test_#1.jld2` and then save a new `test.jld2` with the latest
 `data`.
 
+Any additional keyword arguments are passed through to wsave (to e.g. enable
+compression).
+
 See also [`tagsave`](@ref).
 """
-function safesave(f, data)
+function safesave(f, data; kwargs...)
     recursively_clear_path(f)
-    wsave(f, data)
+    wsave(f, data; kwargs...)
 end
 
 #take a path of a results file and increment its prefix backup number
@@ -196,9 +201,10 @@ See also [`dict_list`](@ref).
 * `l = 8` : number of characters in the random string.
 * `prefix = ""` : prefix each temporary name will have.
 * `suffix = "jld2"` : ending of the temporary names (no need for the dot).
+* `kwargs...` : Any additional keywords are passed through to wsave (e.g. compression).
 """
 function tmpsave(dicts, tmp = projectdir("_research", "tmp");
-    l = 8, suffix = "jld2", prefix = "")
+    l = 8, suffix = "jld2", prefix = "", kwargs...)
 
     mkpath(tmp)
     n = length(dicts)
@@ -212,7 +218,7 @@ function tmpsave(dicts, tmp = projectdir("_research", "tmp");
         end
         i += 1
         push!(r, x)
-        wsave(joinpath(tmp, x), Dict("params" => copy(dicts[i])))
+        wsave(joinpath(tmp, x), Dict("params" => copy(dicts[i])); kwargs...)
     end
     r
 end

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -56,6 +56,20 @@ end
     @test isfile(sn)
     rm(sn)
 
+    # Check if kwargs propagation works on the example of compression.
+    # We don't actually have a way to check if compression worked, so no explicit @test here.
+    # So we rely on the fact that JLD2/BSON do not complain about being passed the `compress` kw.
+    t = f(simulation)
+    tagsave(savename(simulation, ending), t, gitpath=findproject(), compress=true)
+    file = load(savename(simulation, ending))
+    rm(savename(simulation, ending))
+
+    # Now do the same with the safe option - to also implicitly test safesave.
+    t = f(simulation)
+    tagsave(savename(simulation, ending), t, gitpath=findproject(), safe=true, compress=true)
+    file = load(savename(simulation, ending))
+    rm(savename(simulation, ending))
+
     rm(savename(simulation, ending))
     @test !isfile(savename(simulation, ending))
 
@@ -78,6 +92,14 @@ end
     @test path == savename(simulation, ending)
     sim, path = produce_or_load(simulation, f; suffix = ending)
     @test sim["simulation"].T == T
+    rm(savename(simulation, ending))
+    @test !isfile(savename(simulation, ending))
+
+    # As in `tagsave`, test passing wsave args by passing in the `compress`
+    # option. Again, we don't have a way to check if this worked other
+    # than seeing that it does not crash and burn.
+    sim, path = produce_or_load(simulation, f; suffix = ending,
+                                wsave_args = Dict("compress" => true))
     rm(savename(simulation, ending))
     @test !isfile(savename(simulation, ending))
 


### PR DESCRIPTION
This allows the enabling of compression with JLD2 for example. We use simple keyword propagation in the functions `tagsave`, `safesave` and `tmpsave`. For `produce_and_load` we introduce a new keyword argument `wsave_kwargs` because it already uses keyword propagation to `savename`.

This addresses #274 allowing the pass through of compression options.