### PR TITLE
Add macro `@produce_or_load` to add source file and line tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 2.4.0
 * Add the macro version of `produce_or_load` to enable tagging with the calling source file and line.
-* Refactor `tag!` to avoid code duplication.
 # 2.3.0
 * Enable pass through of kwargs to `wsave` in `produce_or_load`, `tagsave` and `safesave` (to e.g. allow compression in JLD2 files).
 # 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.0
+* Add the macro version of `produce_or_load` to enable tagging with the calling source file and line.
+* Refactor `tag!` to avoid code duplication.
 # 2.3.0
 * Enable pass through of kwargs to `wsave` in `produce_or_load`, `tagsave` and `safesave` (to e.g. allow compression in JLD2 files).
 # 2.2.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/save.md
+++ b/docs/src/save.md
@@ -56,6 +56,7 @@ In addition, it attempts to minimize computing energy spent on getting a result.
 
 ```@docs
 produce_or_load
+@produce_or_load
 istaggable
 ```
 

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -80,27 +80,6 @@ function produce_or_load(path, c, f::Function;
     end
 end
 
-function scripttag!(d::Dict{K,T}, source::LineNumberNode; gitpath = projectdir()) where {K,T}
-    # This duplicates functionality in `tag!`, for use in `@produce_or_load` when we want to only
-    # include the `script` tag but not enable tagging generally.
-    @assert (Symbol <: K) || (String <: K)
-    if K == Symbol
-        scriptname = :script
-    else
-        scriptname = "script"
-    end
-    if haskey(d, scriptname)
-        @warn "The dictionary already has a key named `script`. We won't "*
-            "overwrite it with the script name."
-    else
-        if !(String <: T)
-            d = Dict{K, promote_type(T, String)}(d)
-        end
-        d[scriptname] = relpath(sourcename(source), gitpath)
-    end
-    return d
-end
-
 """
     @produce_or_load([path="",] config, f; kwargs...)
 Same as [`produce_or_load`](@ref) but one more field `:script` is added that records

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -125,8 +125,11 @@ macro produce_or_load(f, path, config, args...)
     return quote
         produce_or_load($(esc(path)), $(esc(config)), $(esc.(convert_to_kw.(args))...)) do k
             data = $(esc(f))(k)
+            # Extract the `gitpath` kw arg if it's there
+            kws = ((;kwargs...)->Dict(kwargs...))($(esc.(convert_to_kw.(args))...))
+            gitpath = get(kws, :gitpath, projectdir())
             # Include the script tag with checking for the type of dict keys, etc.
-            scripttag!(data, $s)
+            scripttag!(data, $s; gitpath = gitpath)
             data
         end
     end

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -254,7 +254,7 @@ Include a `script` field in `d`, containing the source file and line number in
 `source`. Do nothing if the field is already present unless `force = true`. Uses
 `gitpath` to make the source file path relative.
 """
-function scripttag!(d::Dict{K,T}, source::LineNumberNode; gitpath = projectdir(), force = false) where {K<:Union{Symbol,String},T}
+function scripttag!(d::Dict{K,T}, source; gitpath = projectdir(), force = false) where {K<:Union{Symbol,String},T}
     # We want this functionality to be separate from `tag!` to allow
     # inclusion of this information without the git tagging
     # functionality.

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -192,7 +192,8 @@ Dict{Symbol,Any} with 3 entries:
   :x => 3
 ```
 """
-function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, force = false, source = nothing) where {K<:Union{Symbol,String},T}
+function tag!(d::Dict{K,T}; gitpath = projectdir(), storepatch = true, force = false, source = nothing) where {K,T}
+    @assert (K <: Union{Symbol,String}) "We only know how to tag dictionaries that have keys that are strings or symbols"
     c = gitdescribe(gitpath)
     c === nothing && return d # gitpath is not a git repo
 
@@ -254,11 +255,14 @@ Include a `script` field in `d`, containing the source file and line number in
 `source`. Do nothing if the field is already present unless `force = true`. Uses
 `gitpath` to make the source file path relative.
 """
-function scripttag!(d::Dict{K,T}, source; gitpath = projectdir(), force = false) where {K<:Union{Symbol,String},T}
+function scripttag!(d::Dict{K,T}, source; gitpath = projectdir(), force = false) where {K,T}
     # We want this functionality to be separate from `tag!` to allow
     # inclusion of this information without the git tagging
     # functionality.
     # To be used in `tag!` and `@produce_or_load`.
+    # We have to assert the key type here again because `scripttag!` can be called
+    # from `@produce_or_load` without going through `tag!`.
+    @assert (K <: Union{Symbol,String}) "We only know how to tag dictionaries that have keys that are strings or symbols"
     scriptname = keyname(d, :script)
     if haskey(d, scriptname) && !force
         @warn "The dictionary already has a key named `script`. We won't "*

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -106,6 +106,31 @@ end
     @test !isfile(savename(simulation, ending))
 
     @test !isfile(savename(simulation, ending))
+    # Produce and save data, preserve source file name and line for test below.
+    # Line needs to be saved on the same line as produce_or_load!
+    sim, path = @produce_or_load(f, "", simulation, suffix = ending); fname = @__FILE__; line = @__LINE__
+    @test isfile(savename(simulation, ending))
+    @test sim["simulation"].T == T
+    @test path == savename(simulation, ending)
+    sim, path = @produce_or_load(f, "", simulation, suffix = ending)
+    @test sim["simulation"].T == T
+    # Test if source was included and that the file name and line number matches the first invocation
+    # (and not the second!)
+    @test "script" ∈ keys(sim)
+    @test sim["script"] |> typeof == String
+    @test sim["script"] == joinpath(relpath(fname, projectdir()) * "#$(line)")
+    rm(savename(simulation, ending))
+    @test !isfile(savename(simulation, ending))
+
+    # Test if tag = true does not interfere with macro script tagging.
+    sim, path = @produce_or_load(f, "", simulation, tag = true, suffix = ending); fname = @__FILE__; line = @__LINE__
+    sim, path = @produce_or_load(f, "", simulation, suffix = ending)
+    # Test if source was included and that the file name and line number matches the first invocation
+    # (and not the second!)
+    @test sim["script"] == joinpath(relpath(fname, projectdir()) * "#$(line)")
+    rm(savename(simulation, ending))
+
+    @test !isfile(savename(simulation, ending))
     sim, path = produce_or_load("", simulation; suffix = ending) do simulation
         @test typeof(simulation.T) <: Real
         a = rand(10); b = [rand(10) for _ in 1:10]
@@ -158,6 +183,30 @@ end
     # Leave no trace
     rm(sn_uncomp)
     rm(sn_comp)
+
+    # Check the macro version
+    sn_uncomp = savename(Dict("compress" => false), "jld2")
+    sn_comp = savename(Dict("compress" => true), "jld2")
+    # Files cannot exist yet
+    @test !isfile(sn_uncomp)
+    @test !isfile(sn_comp)
+    for compress in [false, true]
+        wsave_kwargs = Dict(:compress => compress)
+        @produce_or_load("", wsave_kwargs, suffix = "jld2", wsave_kwargs=wsave_kwargs) do c
+            data
+        end
+    end
+    # Check if both files exist now
+    @test isfile(sn_uncomp)
+    @test isfile(sn_comp)
+    # Test if the compressed file is smaller
+    size_uncomp = filesize(sn_uncomp)
+    size_comp = filesize(sn_comp)
+    @test size_uncomp > size_comp
+    # Leave no trace
+    rm(sn_uncomp)
+    rm(sn_comp)
+
 end
 
 @test produce_or_load(simulation, f; loadfile = false)[1] == nothing

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -27,6 +27,11 @@ for d in (d1, d2)
     @test d[keytype(d)(:gitcommit)] |> typeof <: String
 end
 
+# Test assertion error when the data has a incompatible key type
+@test_throws AssertionError("We only know how to tag dictionaries that have keys that are strings or symbols") tag!(Dict{Int64,Any}(1 => 2))
+@test_throws AssertionError("We only know how to tag dictionaries that have keys that are strings or symbols") DrWatson.scripttag!(Dict{Int64,Any}(1 => 2), "foo")
+
+
 # @tag!
 for d in (d1, d2)
     d = @tag!(d, gitpath=@__DIR__)


### PR DESCRIPTION
Introduces a macro version of `@produce_or_load` that saves the source
file name and line number of the calling line, similar to `@tagsave`.

Adds tests that check if the appropriate file name and line number was
saved.

This closes #136 .