### PR TITLE
Automatically convert `String` keys to `Symbol`s in `access`.

### DIFF
--- a/src/naming.jl
+++ b/src/naming.jl
@@ -185,6 +185,10 @@ For example, if `c, c.k1` are `NamedTuple`s then
 access(c, keys...) = access(access(c, keys[1]), Base.tail(keys)...)
 access(c::AbstractDict, key) = getindex(c, key)
 access(c, key) = getproperty(c, key)
+# Automatically convert String keys to Symbols (for structs)...
+access(c, key::AbstractString) = access(c, Symbol(key))
+# ...but we need to explicitly allow for String keys in Dicts.
+access(c::AbstractDict, key::AbstractString) = getindex(c, key)
 
 """
     allignore(c) = ()

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -86,6 +86,12 @@ x = A(5, (b = 3, c = 4))
 
 @test savename(x) == "a=5_p=(b=3,c=4)"
 
+# automatic string to symbol conversion in accesses of structs
+@test savename(x, accesses=("a",)) == "a=5"
+# But test that this conversion does not happen for Dicts!
+mixed_str_sym_dict = Dict("a" => 1, :b => 2)
+@test savename(mixed_str_sym_dict, accesses=("a", :b)) == "a=1_b=2"
+
 # empty container
 x = A(5, NamedTuple())
 @test !occursin("p", savename(x))


### PR DESCRIPTION
To make the `savename` `accesses` keyword syntax easier, allow
automatic conversion of `String` keys to `Symbol`s when working with
containers other than `Dict`s. Explicitly continue to allow `String`
keys for `Dict`s.

Includes tests for `String` key to `Symbol` conversion when handling a
struct, and `String` key pass through when handling a `Dict`.

Closes #259.