### PR TITLE
Allow for OrderedDicts to be passed to dict_list and other similar functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
 version = "2.4.1"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -23,6 +24,7 @@ julia = "1.0"
 [extras]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -30,10 +32,6 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 
 [targets]
-test = [
-    "Test", "BSON", "FileIO", "Parameters", "DataFrames",
-    "JLD2", "Statistics", "Dates", "CSVFiles", "CodecZlib"
-]
+test = ["Test", "BSON", "FileIO", "Parameters", "DataFrames", "JLD2", "Statistics", "Dates", "CSVFiles", "CodecZlib"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
 version = "2.4.1"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -26,6 +25,7 @@ BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
@@ -34,4 +34,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "BSON", "FileIO", "Parameters", "DataFrames", "JLD2", "Statistics", "Dates", "CSVFiles", "CodecZlib"]
+test = ["Test", "BSON", "FileIO", "Parameters", "DataFrames", "JLD2", "Statistics", "Dates", "CSVFiles", "CodecZlib", "DataStructures"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
 version = "2.4.1"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -1,8 +1,10 @@
 "The perfect sidekick to your scientific inquiries"
 module DrWatson
 import Pkg, LibGit2
-
 const PATH_SEPARATOR = joinpath("_", "_")[2]
+
+using DataStructures
+export OrderedDict
 
 # Misc functions for kw-macros
 convert_to_kw(ex::Expr) = Expr(:kw,ex.args...)

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -3,9 +3,6 @@ module DrWatson
 import Pkg, LibGit2
 const PATH_SEPARATOR = joinpath("_", "_")[2]
 
-using DataStructures
-export OrderedDict
-
 # Misc functions for kw-macros
 convert_to_kw(ex::Expr) = Expr(:kw,ex.args...)
 convert_to_kw(ex) = error("invalid keyword argument syntax \"$ex\"")

--- a/src/dict_list.jl
+++ b/src/dict_list.jl
@@ -105,21 +105,13 @@ function _dict_list(c::AbstractDict)
         map(Iterators.product(values(iterable_dict)...)) do vals
             dd = [k=>convert(eltype(c[k]),v) for (k,v) in zip(keys(iterable_dict),vals)]
             if isempty(non_iterable_dict)
-                if isa(c,OrderedDict)
-                    OrderedDict(dd)
-                else
-                    Dict(dd)
-                end
+                Dict(dd)
             elseif isempty(iterable_dict)
                 non_iterable_dict
             else
                 # We can't use merge here because it promotes types.
                 # The uniqueness of the dictionary keys is guaranteed.
-                if isa(c,OrderedDict)
-                    OrderedDict(dd..., collect(non_iterable_dict)...)
-                else
-                    Dict(dd..., collect(non_iterable_dict)...)
-                end
+                Dict(dd..., collect(non_iterable_dict)...)
             end
         end
     )

--- a/src/dict_list.jl
+++ b/src/dict_list.jl
@@ -1,5 +1,5 @@
 """
-    dict_list(c::Dict)
+    dict_list(c::AbstractDict)
 Expand the dictionary `c` into a vector of dictionaries.
 Each entry has a unique combination from the product of the `Vector`
 values of the dictionary while the non-`Vector` values are kept constant
@@ -47,7 +47,7 @@ julia> dict_list(c)
  Dict(:a=>2,:b=>4,:run=>"tri",:e=>[3, 5],:model=>"linear")
 ```
 """
-function dict_list(c::Dict)
+function dict_list(c::AbstractDict)
     if contains_partially_restricted(c)
         # The method for generating the restricted parameter set is as follows:
         # 1. Remove any nested parameter restrictions (#209)
@@ -94,7 +94,7 @@ function is_solution_subset_of_existing(trial, trial_solutions)
     return false
 end
 
-function _dict_list(c::Dict)
+function _dict_list(c::AbstractDict)
     iterable_fields = filter(k -> typeof(c[k]) <: Vector, keys(c))
     non_iterables = setdiff(keys(c), iterable_fields)
 
@@ -105,13 +105,21 @@ function _dict_list(c::Dict)
         map(Iterators.product(values(iterable_dict)...)) do vals
             dd = [k=>convert(eltype(c[k]),v) for (k,v) in zip(keys(iterable_dict),vals)]
             if isempty(non_iterable_dict)
-                Dict(dd)
+                if isa(c,OrderedDict)
+                    OrderedDict(dd)
+                else
+                    Dict(dd)
+                end
             elseif isempty(iterable_dict)
                 non_iterable_dict
             else
                 # We can't use merge here because it promotes types.
                 # The uniqueness of the dictionary keys is guaranteed.
-                Dict(dd..., collect(non_iterable_dict)...)
+                if isa(c,OrderedDict)
+                    OrderedDict(dd..., collect(non_iterable_dict)...)
+                else
+                    Dict(dd..., collect(non_iterable_dict)...)
+                end
             end
         end
     )
@@ -152,7 +160,7 @@ function DependentParameter(value::DependentParameter, condition::Function)
     DependentParameter(value.value, new_condition)
 end
 
-contains_partially_restricted(d::Dict) = any(contains_partially_restricted,values(d))
+contains_partially_restricted(d::AbstractDict) = any(contains_partially_restricted,values(d))
 contains_partially_restricted(d::Vector) = any(contains_partially_restricted,d)
 contains_partially_restricted(::DependentParameter) = true
 contains_partially_restricted(::Any) = false
@@ -170,7 +178,7 @@ In a case like this:
 
 Broadcasting is obviously not wanted as `:b` should retain it's type of `Vector{Int}`.
 """
-function unexpand_restricted(c::Dict{T}) where T
+function unexpand_restricted(c::AbstractDict{T}) where T
     _c = Dict{T,Any}() # There are hardly any cases where this will not be any.
     for k in keys(c)
         if c[k] isa AbstractVector && any(el->eltype(el) <: DependentParameter, c[k])

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -60,7 +60,7 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
   called with its default arguments (so customization here is possible only
   by rolling your own container type). Containers leading to empty `savename`
   are skipped.
-* `equals = "="` : Connector between name and value. Can be useful to modify for 
+* `equals = "="` : Connector between name and value. Can be useful to modify for
   adding space `" = "`.
 
 ## Examples
@@ -271,7 +271,7 @@ end
 
 """
     esc_dict_expr_from_vars(vars)
-Transform a `Tuple` of `Symbol` and assignments (`a=b`) 
+Transform a `Tuple` of `Symbol` and assignments (`a=b`)
 into a dictionary where each `Symbol` in `vars`
 defines a key-value pair. The value is obtained by evaluating the `Symbol` in
 the macro calling environment.
@@ -356,10 +356,10 @@ ntuple2dict(nt::NamedTuple) = Dict(k => nt[k] for k in keys(nt))
 Convert a dictionary (with `Symbol` or `String` as key type) to
 a `NamedTuple`.
 """
-function dict2ntuple(dict::Dict{String, T}) where T
+function dict2ntuple(dict::AbstractDict{String, T}) where T
     NamedTuple{Tuple(Symbol.(keys(dict)))}(values(dict))
 end
-function dict2ntuple(dict::Dict{Symbol, T}) where T
+function dict2ntuple(dict::AbstractDict{Symbol, T}) where T
     NamedTuple{Tuple(keys(dict))}(values(dict))
 end
 

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -369,14 +369,13 @@ Change a dictionary with key type `Symbol` to have key type `String`.
 """
 tostringdict(::Type{DT},d) where {DT<:AbstractDict} = DT(zip(String.(keys(d)), values(d)))
 tostringdict(d) = tostringdict(Dict,d)
-#tostringdict(d) = Dict(zip(String.(keys(d)), values(d)))
 
 """
     tosymboldict(d)
 Change a dictionary with key type `String` to have key type `Symbol`.
 """
 tosymboldict(::Type{DT},d) where {DT<:AbstractDict} = DT(zip(Symbol.(keys(d)), values(d)))
-tosymboldict(d) = tosymboldict(Dict,d)#Dict(zip(Symbol.(keys(d)), values(d)))
+tosymboldict(d) = tosymboldict(Dict,d)
 
 """
     parse_savename(filename::AbstractString; kwargs...)
@@ -410,7 +409,7 @@ function parse_savename(filename::AbstractString;
     last_dot = findlast(".",savename_part)
     if last_dot == nothing || last_eq > last_dot
         # if no dot is after the last "="
-        # there is no suffixf
+        # there is no suffix
         name, suffix = savename_part,""
     else
         # Check if the last dot is part of a float number by parsing it as Int

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -367,13 +367,16 @@ end
     tostringdict(d)
 Change a dictionary with key type `Symbol` to have key type `String`.
 """
-tostringdict(d) = Dict(zip(String.(keys(d)), values(d)))
+tostringdict(::Type{DT},d) where {DT<:AbstractDict} = DT(zip(String.(keys(d)), values(d)))
+tostringdict(d) = tostringdict(Dict,d)
+#tostringdict(d) = Dict(zip(String.(keys(d)), values(d)))
 
 """
     tosymboldict(d)
 Change a dictionary with key type `String` to have key type `Symbol`.
 """
-tosymboldict(d) = Dict(zip(Symbol.(keys(d)), values(d)))
+tosymboldict(::Type{DT},d) where {DT<:AbstractDict} = DT(zip(Symbol.(keys(d)), values(d)))
+tosymboldict(d) = tosymboldict(Dict,d)#Dict(zip(Symbol.(keys(d)), values(d)))
 
 """
     parse_savename(filename::AbstractString; kwargs...)
@@ -407,7 +410,7 @@ function parse_savename(filename::AbstractString;
     last_dot = findlast(".",savename_part)
     if last_dot == nothing || last_eq > last_dot
         # if no dot is after the last "="
-        # there is no suffix
+        # there is no suffixf
         name, suffix = savename_part,""
     else
         # Check if the last dot is part of a float number by parsing it as Int

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -10,7 +10,7 @@ with the global path that it is saved at (`s`).
 If the file does not exist then call `file = f(config)`, with `f` your function
 that produces your data. Then save the `file` as `s` and then return `file, s`.
 
-The function `f` should return a dictionary if the data are saved in the default 
+The function `f` should return a dictionary if the data are saved in the default
 format of JLD2.jl., the macro [`@strdict`](@ref) can help with that.
 
 You can use a [do-block]
@@ -118,7 +118,7 @@ end
 #                             tag saving                                       #
 ################################################################################
 """
-    tagsave(file::String, d::Dict; safe = false, gitpath = projectdir(), storepatch = true, force = false, kwargs...)
+    tagsave(file::String, d::AbstractDict; safe = false, gitpath = projectdir(), storepatch = true, force = false, kwargs...)
 First [`tag!`](@ref) dictionary `d` and then save `d` in `file`.
 If `safe = true` save the file using [`safesave`](@ref).
 
@@ -144,7 +144,7 @@ end
 
 
 """
-    @tagsave(file::String, d::Dict; kwargs...)
+    @tagsave(file::String, d::AbstractDict; kwargs...)
 Same as [`tagsave`](@ref) but one more field `:script` is added that records
 the local path of the script and line number that called `@tagsave`, see [`@tag!`](@ref).
 """

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -338,7 +338,7 @@ istaggable(x) = x isa AbstractDict
 
 
 """
-    struct2dict(::Type{DT},s) -> d where {DT<: AbstractDict}
+    struct2dict([type = Dict,] s) -> d
 Convert a Julia composite type `s` to a dictionary `d` with key type `Symbol`
 that maps each field of `s` to its value. Simply passing `s` will return a regular dictionary.
 This can be useful in e.g. saving:

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -240,14 +240,22 @@ end
     checktagtype!(d::AbstractDict{K,T}) where {K<:Union{Symbol,String},T}
 
 Check if the value type of `d` allows `String` and promote it to do so if not.
-Currently will accept an abstract dict, but will return a dict.
 """
 function checktagtype!(d::AbstractDict{K,T}) where {K<:Union{Symbol,String},T}
+    DT = get_rawtype(typeof(d)) #concrete type of dictionary
     if !(String <: T)
-        d = Dict{K, promote_type(T, String)}(d)
+        d = DT{K, promote_type(T, String)}(d)
     end
     d
 end
+
+"""
+    get_rawtype(D::DataType) = getproperty(parentmodule(D), nameof(D))
+
+Return Concrete DataType from an `AbstractDict` `D`. Found online at:
+https://discourse.julialang.org/t/retrieve-the-type-of-abstractdict-without-parameters-from-a-concrete-dictionary-type/67567/3
+"""
+get_rawtype(D::DataType) = getproperty(parentmodule(D), nameof(D))
 
 """
     scripttag!(d::AbstractDict{K,T}, source::LineNumberNode; gitpath = projectdir(), force = false) where {K<:Union{Symbol,String},T}
@@ -337,8 +345,6 @@ This can be useful in e.g. saving:
 ```
 tagsave(savename(s), struct2dict(s))
 ```
-
-
 """
 function struct2dict(::Type{DT},s) where {DT<:AbstractDict}
         DT(x => getfield(s, x) for x in fieldnames(typeof(s)))

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -330,22 +330,20 @@ istaggable(x) = x isa AbstractDict
 
 
 """
-    struct2dict(s;order=false) -> d
+    struct2dict(::Type{DT},s) -> d where {DT<: AbstractDict}
 Convert a Julia composite type `s` to a dictionary `d` with key type `Symbol`
-that maps each field of `s` to its value. set `order` = `true` to return an
-ordered dictionary.
+that maps each field of `s` to its value. Simply passing `s` will return a regular dictionary.
 This can be useful in e.g. saving:
 ```
 tagsave(savename(s), struct2dict(s))
 ```
+
+
 """
-function struct2dict(s;order=false)
-    if order
-        OrderedDict(x => getfield(s, x) for x in fieldnames(typeof(s)))
-    else
-        Dict(x => getfield(s, x) for x in fieldnames(typeof(s)))
-    end
+function struct2dict(::Type{DT},s) where {DT<:AbstractDict}
+        DT(x => getfield(s, x) for x in fieldnames(typeof(s)))
 end
+struct2dict(s) = struct2dict(Dict,s)
 
 """
     struct2ntuple(s) -> n

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -270,21 +270,8 @@ for r in ret
 end
 rm(tmpdir, force = true, recursive = true)
 @test !isdir(tmpdir)
-
-
-### test dict_list with OrderedDict and @onlyif calls
-@test Set(dict_list(OrderedDict(
-                 :b=>[1,2],
-                 :a => [3,4],
-                 :c => @onlyif( :b == 2, [5, @onlyif(:a == 4, 6)])
-                ))) == Set([OrderedDict(:b => 1,:a => 3),
-                            OrderedDict(:b => 2,:a => 3,:c => 5),
-                            OrderedDict(:b => 1,:a => 4),
-                            OrderedDict(:b => 2,:a => 4,:c => 5),
-                            OrderedDict(:b => 2,:a => 4,:c => 6)])
 ## is taggable
 @test DrWatson.istaggable("test.jld2")
 @test !DrWatson.istaggable("test.csv")
 @test !DrWatson.istaggable(0.5)
 @test DrWatson.istaggable(Dict(:a => 0.5))
-@test DrWatson.istaggable(OrderedDict(:a=>0.5))

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -239,8 +239,8 @@ p = Dict(
 
 # Testing nested @onlyif calls
 @test Set(dict_list(Dict(
-                   :a=>[1,2], 
-                   :b => [3,4], 
+                   :a=>[1,2],
+                   :b => [3,4],
                    :c => @onlyif( :a == 2, [5, @onlyif(:b == 4, 6)])
                   ))) == Set([Dict(:a => 1,:b => 3),
                               Dict(:a => 2,:b => 3,:c => 5),
@@ -271,8 +271,20 @@ end
 rm(tmpdir, force = true, recursive = true)
 @test !isdir(tmpdir)
 
-## is taggable 
+
+### test dict_list with OrderedDict and @onlyif calls
+@test Set(dict_list(OrderedDict(
+                 :b=>[1,2],
+                 :a => [3,4],
+                 :c => @onlyif( :b == 2, [5, @onlyif(:a == 4, 6)])
+                ))) == Set([OrderedDict(:b => 1,:a => 3),
+                            OrderedDict(:b => 2,:a => 3,:c => 5),
+                            OrderedDict(:b => 1,:a => 4),
+                            OrderedDict(:b => 2,:a => 4,:c => 5),
+                            OrderedDict(:b => 2,:a => 4,:c => 6)])
+## is taggable
 @test DrWatson.istaggable("test.jld2")
 @test !DrWatson.istaggable("test.csv")
 @test !DrWatson.istaggable(0.5)
 @test DrWatson.istaggable(Dict(:a => 0.5))
+@test DrWatson.istaggable(OrderedDict(:a=>0.5))


### PR DESCRIPTION
Anywhere where functions required the input to be a `::Dict{K,T}` were changed to `::AbstractDict{K,T}` to allow for OrderedDicts.

The only place this was not changed was in the project_setup where it gets the `pkg["name"]` because that returns a Dict.

- Added an optional kwarg `order` argument to `struct2dict` to return an OrderedDict (default is false), where order refers to insertion order. If a set of OrderedDicts is used with `dict_list` an OrderedDict should be returned.
- added a test for using dict_list with an Ordered Dict
- `OrderedDict` from DataStructures is also exported from DrWatson.
- `checktagtype!` will also return a regular Dict.

Fixes #278 at the most basic level. 