### PR TITLE
Introduce `update` argument to `collect_results!` to sync results files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.5.0
-* Add an `update` option ot `collect_results!` allowing the updating of an existing results collection if data files were modified or deleted.
+* Add an `update` option of `collect_results!` allowing the updating of an existing results collection if data files were modified or deleted.
 # 2.4.1
 * `savename`'s default options now have `sigdigits = 3` instead of `digits = 3` as stated in the documentation string. This was supposed to happen already since 2.0 but did not because of a bug. (#284)
 * Any subtypes of `AbstractDict` now work with DrWatson (#283).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.5.0
+* Add an `update` option ot `collect_results!` allowing the updating of an existing results collection if data files were modified or deleted.
 # 2.4.1
 * `savename`'s default options now have `sigdigits = 3` instead of `digits = 3` as stated in the documentation string. This was supposed to happen already since 2.0 but did not because of a bug. (#284)
 * Any subtypes of `AbstractDict` now work with DrWatson (#283).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.4.4"
+version = "2.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -136,7 +136,7 @@ subfolders = true, special_list=special_list, black_list = black_list)
 #                           test updating feature                             #
 ###############################################################################
 
-@testset "Test updating feature $(mtime_df ? "without" : "with") :_mtime information" for mtime_df in [false, true]
+@testset "Test updating feature $(mtime_info)" for mtime_info in ["with mtime", "without initial update", "without mtime", "with corrupt mtime"]
     # Create a temp directory and run the tests, creating files in that folder
     # Julia takes care of removing the folder after the function is done.
     mktempdir(datadir()) do folder
@@ -154,37 +154,47 @@ subfolders = true, special_list=special_list, black_list = black_list)
         DrWatson.wsave(fname_modify, d)
 
         # Collect our "results"
-        cres_before = collect_results!(folder; update = true)
-        if mtime_df
+        if mtime_info == "without initial update"
+            # Test this case: https://github.com/JuliaDynamics/DrWatson.jl/pull/286#pullrequestreview-755999610
+            cres_before = collect_results!(folder; update = false)
+        else
+            cres_before = collect_results!(folder; update = true)
+        end
+
+        if mtime_info == "without mtime"
             # Leave out the mtime information to simulate old results collection.
             wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before))
+        elseif mtime_info == "with corrupt mtime"
+            # Corrupt mtime information
+            wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before, "mtime" => Dict{String,Float64}()))
+        else
+            # Modify one data file
+            d = Dict("idx" => :to_modify, "b" => "modified_value")
+            DrWatson.wsave(fname_modify, d)
+
+            # Delete another data file
+            rm(fname_delete)
         end
-
-        # Modify one data file
-        d = Dict("idx" => :to_modify, "b" => "modified_value")
-        DrWatson.wsave(fname_modify, d)
-
-        # Delete another data file
-        rm(fname_delete)
 
         # Collect the "results" again
-        if mtime_df
-            cres_after = @test_logs (:warn, "Update of existing results collection requested, but no previously recorded modification time found. Will proceed by comparing with the database modification time, but this may miss modifications if the database is newer than the modified files.") match_mode=:any collect_results!(folder; update = true)
+        if (mtime_info == "without mtime") || (mtime_info == "with corrupt mtime") 
+            @test_throws DrWatson.InvalidResultsCollection collect_results!(folder; update = true)
         else
             cres_after = collect_results!(folder; update = true)
-        end
 
-        # Compare the before and after - they should differ
-        @test cres_before[:,[:idx, :b]] != cres_after[:,[:idx, :b]]
-        # The unmodified entry should be the same
-        @test ((:keep ∈ cres_before.idx) && (:keep ∈ cres_after.idx))
-        # The deleted entry should be gone
-        @test ((:delete ∈ cres_before.idx) && (:delete ∉ cres_after.idx))
+            # Compare the before and after - they should differ
+            @test cres_before[:,[:idx, :b]] != cres_after[:,[:idx, :b]]
+            # The unmodified entry should be the same
+            @test ((:keep ∈ cres_before.idx) && (:keep ∈ cres_after.idx))
+            # The deleted entry should be gone
+            @test ((:delete ∈ cres_before.idx) && (:delete ∉ cres_after.idx))
             # The modified entry should differ between before and after
-        @test cres_before.b[cres_before.idx .== :to_modify][1] == "original_value"
-        @test cres_after.b[cres_after.idx .== :to_modify][1] == "modified_value"
+            @test cres_before.b[cres_before.idx .== :to_modify][1] == "original_value"
+            @test cres_after.b[cres_after.idx .== :to_modify][1] == "modified_value"
+        end
     end
 end
+
 
 ###############################################################################
 #                              Quickactivate macro                            #

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -51,7 +51,7 @@ isfile(defaultname) && rm(defaultname)
 cres = collect_results!(defaultname, folder;
     subfolders = true, special_list=special_list, black_list = black_list)
 
-@test size(cres) == (4, 7)
+@test size(cres) == (4, 6)
 for n in ("a", "b", "lv_mean")
     @test n ∈ String.(names(cres))
 end
@@ -79,7 +79,7 @@ DrWatson.wsave(savename(d)*".jld2", d)
 cres2 = collect_results!(defaultname, folder;
     subfolders = true, special_list=special_list, black_list = black_list)
 
-@test size(cres2) == (6, 8)
+@test size(cres2) == (6, 7)
 @test all(names(cres) .∈ Ref(names(cres2)))
 
 ###############################################################################
@@ -98,7 +98,7 @@ isfile(defaultname2) && rm(defaultname2)
 cres10 = collect_results!(defaultname2, folder;
     subfolders = true, special_list=special_list2, black_list = black_list)
 
-@test size(cres10) == (6, 10)
+@test size(cres10) == (6, 9)
 for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
     @test n ∈ String.(names(cres10))
 end
@@ -119,7 +119,7 @@ rm(defaultname)
 cres_empty = collect_results!(defaultname, folder;
     subfolders = true, special_list=special_list, white_list=[])
 
-@test dropmissing(cres2[!,[:lv_mean, :lv_var, :path, :_mtime]]) == dropmissing(cres_empty)
+@test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
 
 ###############################################################################
 #                           test out-of-place form                            #
@@ -156,8 +156,7 @@ subfolders = true, special_list=special_list, black_list = black_list)
         # Collect our "results"
         cres_before = collect_results!(folder; update = true)
         if mtime_df
-            # Delete the mtime information to simulate old results collection.
-            select!(cres_before, Not(:_mtime))
+            # Leave out the mtime information to simulate old results collection.
             wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before))
         end
 


### PR DESCRIPTION
I often re-run a computation or data analysis that results in some updated data files. But this isn't propagated through to the results database by `collect_results!` because that only looks for new files but leaves entries for files that have already existed but are now changed alone. The only way to trigger an update is to delete the results database. However, I often run some moderately lengthy computation in `collect_results!` using the `special_list` argument and want to avoid doing that for the whole collection of data files.

This PR adds an `update` keyword argument to `collect_results!` (defaulting to `false`). If `true` it actively syncs an existing results database with the raw data file collection. In particular, when it encounters files whose `mtime` is younger than the result database's `mtime`, it removes the corresponding entry from the database and recreates it using the newer file's data. When it encounters an entry for a file that does not exist anymore it removes that entry.

A few points:
* This is loosely connected with the discussion in #150, about having a way for `produce_or_load` to check if a file needs to be updated because the code changed.
* This might stray into "give the user enough rope to hang themselves" territory. I'm curious what you think about it, but it is definitely useful for me. But I do understand if you don't want to merge this because of data safety concerns.
* I haven't yet added a dire warning to the documentation of the function that "this can mess with your results databases, so do not activate if you do not want that!", but something like this should probably go in.
* I only tested this on macos, but it should work the same on Linux. I don't have a way to test it on Windows, where `mtime` might not work as expected. I wrote tests for it, so it should be revealed during the CI run. 
* Alternatively, the update check could be done by using file hashes instead of `mtime`, but this would be slightly more costly, albeit more portable across platforms.