### PR TITLE
Added support for returning `OrderedDict` when using `ntuple2dict`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.4.1"
+version = "2.4.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -346,7 +346,7 @@ end
 # Credit of `ntuple` macro goes to Sebastian Pfitzner, @pfitzseb
 
 """
-    ntuple2dict(nt) -> dict
+    ntuple2dict([type = Dict,] nt) -> dict
 Convert a `NamedTuple` to a dictionary.
 """
 ntuple2dict(::Type{DT},nt::NamedTuple) where {DT<:AbstractDict} = DT(k => nt[k] for k in keys(nt))

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -349,7 +349,8 @@ end
     ntuple2dict(nt) -> dict
 Convert a `NamedTuple` to a dictionary.
 """
-ntuple2dict(nt::NamedTuple) = Dict(k => nt[k] for k in keys(nt))
+ntuple2dict(::Type{DT},nt::NamedTuple) where {DT<:AbstractDict} = DT(k => nt[k] for k in keys(nt))
+ntuple2dict(nt::NamedTuple) = ntuple2dict(Dict,nt)
 
 """
     dict2ntuple(dict) -> ntuple

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -313,6 +313,12 @@ rm(tmpdir, force = true, recursive = true)
     d11 = tosymboldict(OrderedDict,d10)
     @test isa(d11,OrderedDict)
 
+    #test ntuple2dict
+    x = 3; y = 5.0;
+    n = @ntuple x y
+    @test isa(ntuple2dict(n),Dict)
+    @test isa(ntuple2dict(OrderedDict,n),OrderedDict)
+    
     #test checktagtype!
     @test isa(DrWatson.checktagtype!(d3),Dict)
     @test isa(DrWatson.checktagtype!(d11),OrderedDict)


### PR DESCRIPTION
Missed the addition of supporting `OrderedDict` in `ntuple2dict with pull request #283. 