### PR TITLE
Use `jldopen` in `collect_results!` when scanning JLD2 files.

### DIFF
--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -45,6 +45,19 @@ using Requires
 function __init__()
     @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
         include("result_collection.jl")
+        @require JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819" begin
+            using .JLD2
+            # This allows us to use the much faster jldopen in collect_results
+            function load_jld2(f, path)
+                @debug "Opening $(path) with jldopen."
+                jldopen(path) do data
+                    return f(data)
+                end
+            end
+            ext_register[".jld2"] = load_jld2
+            # JLD2 doesn't define keytype, but only supports Strings anyway.
+            Base.keytype(f::JLD2.JLDFile) = String
+        end
     end
 end
 

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -195,6 +195,27 @@ subfolders = true, special_list=special_list, black_list = black_list)
     end
 end
 
+###############################################################################
+#                           test jldopen                                      #
+###############################################################################
+
+mktempdir(datadir()) do folder
+    # Create a data file
+    d = Dict("idx" => 1, "value" => rand(100000))
+    fname = joinpath(folder, savename(d, ending, ignores = ("value",)))
+    DrWatson.wsave(fname, d)
+
+    if ending == "jld2"
+        msg_re = r"Opening .* with jldopen."
+    else
+        msg_re = r"Opening .* with fallback wload."
+    end
+    @test_logs (:debug, msg_re) min_level=Base.CoreLogging.Debug match_mode=:any cres = collect_results(folder, black_list = ("value",))
+
+    @test cres.idx[1] == 1 # It's what we've saved above.
+    @test size(cres,1) == 1 # only one file
+    @test size(cres,2) == 2 # idx and path
+end
 
 ###############################################################################
 #                              Quickactivate macro                            #


### PR DESCRIPTION
Employ lazy loading via Requires.jl to allow special load functions for particular file types in `collect_results!`, and falling back to `wload` as a default. This potentially makes scanning collections of large files much faster when using the `black_list` argument of `collect_results!`.

An example use case are simulations that generate amounts of data where the parameters are stored in a Dict, together with the data under the keyword `data`, all saved in a JLD2 file. If we only want to enumerate all the parameters that have been run, we would use `collect_results(datadir("simulations"), black_list = ("data",))`. With `wload`, this still loads the whole file into memory before ignoring the `data` key. With `jldopen`, only the parameters are loaded into memory. In my tests, this leads to around 400x speed up when scanning large collections of files.

For now, only `jldopen` for JLD2 files is implemented, but this could potentially be extended to other data storage formats that allow memory mapped access to storage keys.