### PR TITLE
Fix recursively_clear_path for directories

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.7.3"
+version = "2.7.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -222,9 +222,9 @@ end
 
 #recursively move files to increased backup number
 function recursively_clear_path(cur_path)
-    isfile(cur_path) || return
+    ispath(cur_path) || return
     new_path=increment_backup_num(cur_path)
-    if isfile(new_path)
+    if ispath(new_path)
         recursively_clear_path(new_path)
     end
     mv(cur_path, new_path)

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -24,7 +24,7 @@ end
 
 ## Keywords
 * `suffix = "jld2", prefix = default_prefix(config)` : Used in [`savename`](@ref).
-* `tag::Bool = get(ENV, "DRWATSON_TAG", istaggable(suffix))` : Save the file 
+* `tag::Bool = get(ENV, "DRWATSON_TAG", istaggable(suffix))` : Save the file
   using [`tagsave`](@ref) if `true` (which is the default).
 * `gitpath, storepatch` : Given to [`tagsave`](@ref) if `tag` is `true`.
 * `force = false` : If `true` then don't check if file `s` exists and produce
@@ -43,10 +43,10 @@ produce_or_load(f::Function, c; kwargs...) = produce_or_load(c, f; kwargs...)
 produce_or_load(f::Function, path, c; kwargs...) = produce_or_load(path, c, f; kwargs...)
 function produce_or_load(path, c, f::Function;
         suffix = "jld2", prefix = default_prefix(c),
-        tag::Bool = get(ENV, "DRWATSON_TAG", istaggable(suffix)), 
+        tag::Bool = get(ENV, "DRWATSON_TAG", istaggable(suffix)),
         gitpath = projectdir(), loadfile = true,
-        storepatch::Bool = get(ENV, "DRWATSON_STOREPATCH", false), 
-        force = false, verbose = true, wsave_kwargs = Dict(), 
+        storepatch::Bool = get(ENV, "DRWATSON_STOREPATCH", false),
+        force = false, verbose = true, wsave_kwargs = Dict(),
         kwargs...
     )
 
@@ -140,10 +140,10 @@ enable compression.
 The keyword `safe = get(ENV, "DRWATSON_SAFESAVE", false)` decides whether
 to save the file using [`safesave`](@ref).
 """
-function tagsave(file, d; 
-        gitpath = projectdir(), 
-        safe::Bool = get(ENV, "DRWATSON_SAFESAVE", false), 
-        storepatch::Bool = get(ENV, "DRWATSON_STOREPATCH", false), 
+function tagsave(file, d;
+        gitpath = projectdir(),
+        safe::Bool = get(ENV, "DRWATSON_SAFESAVE", false),
+        storepatch::Bool = get(ENV, "DRWATSON_STOREPATCH", false),
         force = false, source = nothing, kwargs...
     )
     d2 = tag!(d, gitpath=gitpath, storepatch=storepatch, force=force, source=source)

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -252,3 +252,24 @@ end
     rm("test.#backup_#1."*ending)
     rm("test.#backup_#2."*ending)
 end
+
+@testset "Backup (dir)" begin
+    # Save contents as individual file(s) within a parent directory:
+    struct Composite x end
+    DrWatson._wsave(dir, data::Composite) = wsave(joinpath(dir, "x.jld2"), data.x)
+    load_composite(dir) = load(joinpath(dir, "x.jld2"))
+
+    filepath = "test.#backup.dir"
+    data = [Composite(Dict( "a" => i, "b" => rand(rand(1:10)))) for i = 1:3]
+    for i = 1:3
+        safesave(filepath, data[i])
+        @test isdir(filepath)
+        @test data[i].x == load_composite(filepath)
+    end
+    @test data[2].x == load_composite("test.#backup_#1.dir")
+    @test data[1].x == load_composite("test.#backup_#2.dir")
+    @test data[3].x == load_composite("test.#backup.dir")
+    rm("test.#backup.dir"; recursive=true)
+    rm("test.#backup_#1.dir"; recursive=true)
+    rm("test.#backup_#2.dir"; recursive=true)
+end


### PR DESCRIPTION
Suppose you would like to save a custom data structure as a directory containing several files (or other directories). This fixes the `wsave` machinery for that use case.

I am working on a cluster and my result type holds `Future`s (non-cached, i.e. having `fut.v == nothing`, though I'm considering to move to [DeferredFutures.jl](https://github.com/invenia/DeferredFutures.jl)) to data on different nodes. I would like to have each node/worker write a separate file to disk, such that I don't need to transfer all the data to the managing process.

If there is anything I missed, or you've got any suggestions, I'm all ears. 🙂 