### PR TITLE
Custom types for wload to be used with produce_or_load

### DIFF
--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -35,8 +35,21 @@ function wsave(filename, data...; kwargs...)
     return _wsave(filename, data...; kwargs...)
 end
 
-"Currently equivalent with `FileIO.load`."
+"""
+    wload([::DataType], args...; kwargs...)
+
+Default fallback is `FileIO.load`, discarding the (optional) first argument.
+Extend this for your types as the first argument:
+
+```julia
+struct TheAnswer end
+
+DrWatson.wload(::Type{TheAnswer}) = TheAnswer()
+```
+"""
+function wload end
 wload(data...; kwargs...) = FileIO.load(data...; kwargs...)
+wload(::DataType, data...; kwargs...) = FileIO.load(data...; kwargs...)
 
 include("saving_files.jl")
 include("dict_list.jl")

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -36,6 +36,10 @@ end
 * `verbose = true` : print info about the process, if the file doesn't exist.
 * `wsave_kwargs = Dict()` : Keywords to pass to `wsave` (e.g. to enable
   compression).
+* `returntype::DataType = Any` : First argument passed to `wload`.
+  Set this if you defined a custom method for `wload`.
+  If `f` does not return a `returntype`, this function will issue a warning.
+  The data is still produced and saved.
 * `kwargs...` : All other keywords are propagated to `savename`.
 """
 produce_or_load(c, f; kwargs...) = produce_or_load("", c, f; kwargs...)
@@ -47,6 +51,7 @@ function produce_or_load(path, c, f::Function;
         gitpath = projectdir(), loadfile = true,
         storepatch::Bool = get(ENV, "DRWATSON_STOREPATCH", false),
         force = false, verbose = true, wsave_kwargs = Dict(),
+        returntype::DataType=Any,
         kwargs...
     )
 
@@ -54,7 +59,7 @@ function produce_or_load(path, c, f::Function;
 
     if !force && isfile(s)
         if loadfile
-            file = wload(s)
+            file = wload(returntype, s)
             return file, s
         else
             return nothing, s
@@ -66,6 +71,9 @@ function produce_or_load(path, c, f::Function;
             verbose && @info "File $s does not exist. Producing it now..."
         end
         file = f(c)
+        if !(file isa returntype)
+            @warn "Data returned from `f` is not a `$returntype`. Saving anyway, but `produce_or_load` might not be able to load the data back."
+        end
         try
             if tag
                 tagsave(s, file; safe = false, gitpath = gitpath, storepatch = storepatch, wsave_kwargs...)


### PR DESCRIPTION
Follow up to [#303#issuecomment-966395495](https://github.com/JuliaDynamics/DrWatson.jl/pull/303#issuecomment-966395495).

This is very much work-in-progress. I just opened the PR so that I won't forget to work on it.

I've had a version that additionally checks wether the user has defined a custom saving method using `isempty(methodswith(returntype, _wsave))` but didn't specify `returntype` to dispatch for `wload`. Though, this is clearly heading towards the "magic" territory from a user's perspective. Is this desirable?

Given that users might have defined methods for `FileIO.load`, which does no longer receive all the arguments passed to `wsave`, how breaking is this?

Also, I didn't test this thoroughly, so even when it's finished, it maybe should simmer a bit before merging.