### PR TITLE
Change dirty suffix from `_dirty` to `-dirty`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.7.4"
+version = "2.7.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -7,20 +7,20 @@ export istaggable
 # Obtaining Git information
 ########################################################################################
 """
-    gitdescribe(gitpath = projectdir()) -> gitstr
+    gitdescribe(gitpath = projectdir(); dirty_suffix = "-dirty") -> gitstr
 
 Return a string `gitstr` with the output of `git describe` if an annotated git tag exists,
 otherwise the current active commit id of the Git repository present
 in `gitpath`, which by default is the currently active project. If the repository
 is dirty when this function is called the string will end
-with `"_dirty"`.
+with `dirty_suffix`.
 
 Return `nothing` if `gitpath` is not a Git repository, i.e. a directory within a git
 repository.
 
 The format of the `git describe` output in general is
 
-    `"TAGNAME-[NUMBER_OF_COMMITS_AHEAD-]gLATEST_COMMIT_HASH[_dirty]"`
+    `"TAGNAME-[NUMBER_OF_COMMITS_AHEAD-]gLATEST_COMMIT_HASH[-dirty]"`
 
 If the latest tag is `v1.2.3` and there are 5 additional commits while the
 latest commit hash is 334a0f225d9fba86161ab4c8892d4f023688159c, the output
@@ -41,10 +41,10 @@ julia> gitdescribe() # a tag doesn't exist
 "96df587e45b29e7a46348a3d780db1f85f41de04"
 
 julia> gitdescribe(path_to_a_dirty_repo)
-"3bf684c6a115e3dce484b7f200b66d3ced8b0832_dirty"
+"3bf684c6a115e3dce484b7f200b66d3ced8b0832-dirty"
 ```
 """
-function gitdescribe(gitpath = projectdir())
+function gitdescribe(gitpath = projectdir(); dirty_suffix::String = "-dirty")
     # Here we test if the gitpath is a git repository.
     try
         repo = LibGit2.GitRepoExt(gitpath)
@@ -61,7 +61,7 @@ function gitdescribe(gitpath = projectdir())
     end
     suffix = ""
     if LibGit2.isdirty(repo)
-        suffix = "_dirty"
+        suffix = dirty_suffix
         @warn "The Git repository ('$gitpath') is dirty! "*
         "Appending $(suffix) to the commit ID."
     end

--- a/test/stools_tests.jl
+++ b/test/stools_tests.jl
@@ -28,9 +28,11 @@ dpath = _setup_repo(true) # dirty
 cpath = _setup_repo(false) # clean
 
 @test isdirty(dpath)
-@test endswith(gitdescribe(dpath), "_dirty")
+@test endswith(gitdescribe(dpath), "-dirty")
+@test endswith(gitdescribe(dpath, dirty_suffix="-verydirty"), "-verydirty")
+@test !endswith(gitdescribe(dpath, dirty_suffix=""), "-dirty")
 @test !isdirty(cpath)
-@test !endswith(gitdescribe(cpath), "_dirty")
+@test !endswith(gitdescribe(cpath), "-dirty")
 
 # tag!
 function _test_tag!(d, path, haspatch, DRWATSON_STOREPATCH)


### PR DESCRIPTION
such that it matches the output of `git describe --dirty`. Do so by
adding a keyword argument to `gitdescribe()` having that new default.

Fix #306