### PR TITLE
Make safesave use the full signature of wsave

### DIFF
--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -190,7 +190,7 @@ end
 
 # Implementation inspired by behavior of GROMACS
 """
-    safesave(filename, data; kwargs...)
+    safesave(filename, data...; kwargs...)
 
 Safely save `data` in `filename` by ensuring that no existing files
 are overwritten. Do this by renaming already existing data with a backup-number
@@ -210,9 +210,9 @@ compression).
 
 See also [`tagsave`](@ref).
 """
-function safesave(f, data; kwargs...)
+function safesave(f, data...; kwargs...)
     recursively_clear_path(f)
-    wsave(f, data; kwargs...)
+    wsave(f, data...; kwargs...)
 end
 
 #take a path of a results file and increment its prefix backup number


### PR DESCRIPTION
If using JLD2, this allows to use the name - value signature of fileio_save.

Since wsave already does this, the lack of ... here is probably just an oversight.