### PR TITLE
Allow arbitrary functions to extract name from configuration in `produce_or_load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.12.0
+- Arbitrary functions extracting strings from data can be used in `produce_or_load` instead of `savename`. `hash` is the most useful function here. An example in Real World Examples highlights this.
+- Additional keywords in `produce_or_load` propagated to `savename` are deprecated.
+- The example project created in the Workflow Tutorial no longer has spaces in its name
+
 # 2.11.0
 - Now the default project with `initialize_project` will include a documentation and a test folder, and setup CI for both automatically.
 - `@produce_or_load` was broken but because CI was disabled this was silently ignored. `produce_or_load` now has call signature `produce_or_load(f::Function, config, path::String = "")` and same signature for the macro with `path` mandatory.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.11.1"
+version = "2.12.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,8 +26,8 @@ DrWatson is part of [JuliaDynamics](https://juliadynamics.github.io/JuliaDynamic
 ## Installing and Updating
 To install or update DrWatson, simply type `] add DrWatson` or `] up DrWatson`, respectively, in your Julia session.
 
-!!! note "Update messages"
-    Upon update DrWatson will display a message highlighting any major changes. To disable these messages set the environment variable `DRWATSON_UPDATE_MSG` to `0` prior to `using DrWatson`. 
+!!! info "Update messages"
+    Upon update DrWatson will display a message highlighting any major changes or major new features. To disable these messages set the environment variable `DRWATSON_UPDATE_MSG` to `0` prior to `using DrWatson`.
 
 ## Rationale
 Have you thought things like:
@@ -125,7 +125,7 @@ or use the DOI directly:
 * <https://github.com/JuliaDocs/Documenter.jl>
 * <https://github.com/fredrikekre/Literate.jl>
 * <https://github.com/caseykneale/Sherlock.jl>
-* <https://github.com/miguelraz/DoctorDocstrings.jl> 
+* <https://github.com/miguelraz/DoctorDocstrings.jl>
 
 ### Paper-related
 * <https://github.com/Humans-of-Julia/Bibliography.jl>

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -268,7 +268,7 @@ using Random
 function sim_large_c(config)
     @unpack x, f = config
     r = sum(x)*f.a + f.t.b + f.t.c
-    return @dict(r)
+    return @strdict(r)
 end
 
 ## Some nested structs

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -275,7 +275,6 @@ rng = Random.MersenneTwister(1234)
 configs = Dict(
     "x" => [rand(Random.MersenneTwister(1234), 1000),
             randn(Random.MersenneTwister(1234), 20)],
-    # :f => [x -> sum(cos.(x)), x -> maximum(abs.(x))],
     "f" => [f1, f2],
 )
 configs = dict_list(configs)

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -257,7 +257,10 @@ Now, every time I run this code block the function tests automatically whether t
 The extra step is that I have to extract the useful data I need from the container `file`. Thankfully the [`@unpack`](@ref) macro, or if your are using Julia v1.5 or later, the named decomposition syntax, `(; a, b) = config`, makes unpacking super easy.
 
 ## `produce_or_load` with hash codes
-As displayed above, [`produce_or_load`](@ref) has a limitation: the filename is what is checked for the existence of the file, i.e., the output of some code. However, in some situations you may have crucial differences between outputs that cannot be encoded simply using the filename. This is, for example, the case where part of the input to the code is some function. Let's say we have a code that has way too many input parameters, all of which are important, but also one of the parameters is a complicated function. In this scenario [`savename`](@ref) which is used by default to extract a name for [`produce_or_load`](@ref) is unfitting. We can instead use base Julia's `hash` though.
+As displayed above, the default setting of [`produce_or_load`](@ref) uses [`savename`](@ref) to extract the filename from the configuration input. This file name is used to check whether the program has run and its output has been saved or not. However, in some situations you may have crucial differences between inputs that cannot be encoded simply using [`savename`](@ref). This is, for example, the case where part of the input to the code is some function, or the input parameters are so many that [`savename`](@ref) would make a file name larger than what operating systems allow.
+
+Thankfully, instead of [`savename`](@ref) we can use base Julia's `hash` function as we will illustrate in the following example.
+
 ```@example customizing
 using DrWatson
 using Random

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -312,7 +312,7 @@ readdir(path)
 ```
 yes.
 But, if we used exactly the same numbers and function, would it yield exactly the
-same ID, and hence, not rerun the simulation (as desired)?
+same hash code, and hence, not rerun the simulation (as desired)?
 
 ```@example customizing
 config = Dict("x" => rand(Random.MersenneTwister(1234)), "f" => f1)

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -321,7 +321,7 @@ readdir(path)
 ```
 Perfect!
 
-!!! warn "Be careful of using `hash`."
+!!! warning "Be careful of using `hash`."
     The limitations of the `hash` function apply here. For example, custom types should implement `==` to ensure `hash` will work as intended.
     In general using functions with `hash` should be avoided. Hashing of functions happens on the function name, and hence it doesn't capture information about the actual code of the function or its methods. So this should only be used if the functions are well-established names coming from e.g. Base Julia such as `sin, cos, ...`. You also cannot use anonymous functions _at all_, as they do not have the same `hash` even when defined in the the same way but in different Julia sessions.
 

--- a/docs/src/real_world.md
+++ b/docs/src/real_world.md
@@ -4,15 +4,15 @@
 I setup all my science projects using DrWatson's suggested setup, using [`initialize_project`](@ref). Then, every file in every project has a start that looks like this:
 ```julia
 using DrWatson
-quickactivate(@__DIR__, "MagneticBilliardsLyapunovs")
-using DynamicalBilliards, PyPlot, LinearAlgebra
+@quickactivate "MagneticBilliardsLyapunovs"
+using DynamicalBilliards, GLMakie, LinearAlgebra
 
 include(srcdir("plot_perturbationgrowth.jl"))
 include(srcdir("unitcells.jl"))
 ```
 In all projects I save data/plots using `datadir/plotdir`:
 ```julia
-@tagsave(datadir("mushrooms", "Λ_N=$N.jld2"), (@strdict Λ Λσ ws hs description))
+@tagsave(datadir("mushrooms", "Λ_N=$N.jld2"), (@strdict(Λ, Λσ, ws, hs, description)))
 ```
 The advantage of this approach is that it will always work regardless of if I move the specific file to a different subfolder (which is very often necessary) or whether I move the entire project folder somewhere else!
 **Please be sure you have understood the caveat of using [`quickactivate`](@ref)!**
@@ -65,8 +65,6 @@ using DrWatson
 @quickactivate :AlbedoProperties
 ```
 which takes advantage of [`@quickactivate`](@ref)'s feature to essentially combine the commands `@quickactivate "AlbedoProperties"` and `using AlbedoProperties` into one.
-
-If you intend to share your project with a non-DrWatson user, you should consider the verbose syntax instead, as the above syntax is not really clear for someone that doesn't know what `@quickactivate` does.
 
 ## `savename` and tagging
 The combination of using [`savename`](@ref) and [`tagsave`](@ref) makes it easy and fast to save output in a way that is consistent, robust and reproducible. Here is an example from a project:
@@ -208,9 +206,9 @@ savename(stt)
 
 
 ## Stopping "Did I run this?"
-It can become very tedious to have a piece of code that you may or may not have run and may or may not have saved the produced data. You then constantly ask yourself "Did I run this?". Typically one uses `isfile` and an `if` clause to either load a file or run some code. Especially in the cases where the code takes only a couple of minutes to finish you are left in a dilemma "Is it even worth it to save?".
+It can become very tedious to have a piece of code that you may or may not have run and may or may not have saved the produced data. You then constantly ask yourself "Did I run this?". Depending on how costly running the code is, having a good framework to answer this question can become very important!
 
-This is the dilemma that [`produce_or_load`](@ref) resolves. You can wrap your code in a function and then [`produce_or_load`](@ref) will take care of the rest for you! I found it especially useful in scripts that generate figures for a publication.
+This is the role of [`produce_or_load`](@ref). You can wrap your code in a function and then [`produce_or_load`](@ref) will take care of the rest for you! I found it especially useful in scripts that generate figures for a publication.
 
 Here is an example; originally I had this piece of code:
 ```julia
@@ -229,11 +227,11 @@ end
 ```
 that was taking some minutes to run. To use the function [`produce_or_load`](@ref) I first have to wrap this code in a high level function like so:
 ```julia
-function g(d)
+function simulation(config)
     HTEST = 0.1:0.1:2.0
     WS = [0.5, 1.0, 1.5]
-    @unpack N, T = d
-    toypar_h = [[] for l in WS]
+    @unpack N, T = config
+    toypar_h = [[] for _ in WS]
 
     for (wi, w) in enumerate(WS)
         println("w = $w")
@@ -249,14 +247,86 @@ N = 2000; T = 2000.0
 data, file = produce_or_load(
     datadir("mushrooms", "toy"), # path
     @dict(N, T), # container
-    g, # function
+    simulation; # function
     prefix = "fig5_toyparams" # prefix for savename
 )
 @unpack toypar_h = data
 ```
 Now, every time I run this code block the function tests automatically whether the file exists. Only if it does not, then the code is run while the new result is saved to ensure I won't have to run it again.
 
-The extra step is that I have to extract the useful data I need from the container `file`. Thankfully the `@unpack` macro from [UnPack.jl](https://github.com/mauro3/UnPack.jl) makes this super easy.
+The extra step is that I have to extract the useful data I need from the container `file`. Thankfully the [`@unpack`](@ref) macro, or if your are using Julia v1.5 or later, the named decomposition syntax, `(; a, b) = config`, makes unpacking super easy.
+
+## `produce_or_load` with Object IDs
+As displayed above, [`produce_or_load`](@ref) has a limitation: the filename is what is checked for the existence of the file, i.e., the output of some code. However, in some situations you may have crucial differences between outputs that cannot be encoded simply using the filename. This is, for example, the case where part of the input to the code is some function. Let's say we have a code that has way too many input parameters, all of which are important, but also one of the parameters is a complicated function. In this scenario [`savename`](@ref) which is used by default to extract a name for [`produce_or_load`](@ref) is unfitting. We can instead use base Julia's `objectid` though.
+```@example customizing
+using DrWatson
+using Random
+
+function sim_with_f(config)
+    @unpack x, f = config
+    r = f(x)
+    return @dict(r)
+end
+
+f1(x) = sum(cos.(x))
+f2(x) = maximum(abs.(x))
+rng = Random.MersenneTwister(1234)
+
+configs = Dict(
+    "x" => [rand(rng, 1000), randn(rng, 2000)],
+    # :f => [x -> sum(cos.(x)), x -> maximum(abs.(x))],
+    "f" => [f1, f2],
+)
+configs = dict_list(configs)
+
+path = mktempdir()
+pol_kwargs = (prefix = "sims_with_f", verbose = false, tag = false)
+
+for config in configs
+    produce_or_load(sim_with_f, config, path; pol_kwargs...)
+end
+
+readdir(path)
+```
+as you can see this is obviously useless :D `savename` didn't return
+anything from the given `config` containers so all data had the same name.
+Let's use `objectid` instead:
+
+```@example customizing
+rm(joinpath(path, "sims_with_f.jld2"))
+for config in configs
+    produce_or_load(sim_with_f, config, path; filename = objectid, pol_kwargs...)
+end
+readdir(path)
+```
+Lovely. But, just to be on the safe side, if we use a different input `x`
+but of same type and size would we get a different file name (as desidred)?
+
+```@example customizing
+config = Dict("x" => rand(Random.MersenneTwister(4321)), "f" => f1)
+produce_or_load(sim_with_f, config, path; filename = objectid, pol_kwargs...)
+readdir(path)
+```
+yes.
+But, if we used exactly the same numbers and function, would it yield exactly the
+same ID, and hence, not rerun the simulation (as desired)?
+
+```@example customizing
+config = Dict("x" => rand(Random.MersenneTwister(1234)), "f" => f1)
+produce_or_load(sim_with_f, config, path; filename = objectid, pol_kwargs...)
+readdir(path)
+```
+Perfect! Be aware and careful of using `objectid` and functions. Anonymous functions
+will definitely mess you up and should be avoided! For example,
+```@example customizing
+an_f = x -> sum(sin.(x))
+config = Dict("x" => rand(Random.MersenneTwister(1234)), "f" => an_f)
+produce_or_load(sim_with_f, config, path; filename = objectid, pol_kwargs...)
+readdir(path)
+```
+So, even though `an_f` is in practice the "same" function as `f1`, they are not the same
+object for the language.
+
 
 ## Preparing & running jobs
 ### Preparing the dictionaries
@@ -512,10 +582,10 @@ function logmessage(n, error)
     # current time
     time = Dates.format(now(UTC), dateformat"yyyy-mm-dd HH:MM:SS")
 
-    # memory the process is using 
+    # memory the process is using
     maxrss = "$(round(Sys.maxrss()/1048576, digits=2)) MiB"
 
-    logdata = (; 
+    logdata = (;
         n, # iteration n
         error, # some super important progress update
         maxrss) # lastly the amount of memory being used
@@ -537,7 +607,7 @@ end
 This yields output that is both easy to read *and* machine parseable.
 If you ever end up with too many logfiles to read, there is still `parse_savename` to
 help you.
- 
+
 ```julia
 julia> expensive_computation(5)
 2021-05-19 19:20:25 | n = 1 | error = 0.65 | maxrss = 326.27 MiB
@@ -551,14 +621,14 @@ julia> expensive_computation(5)
 The point of this section is to show how far one can take the interplay between [`savename`](@ref) and [`produce_or_load`](@ref) to **automate project input-to-output and eliminate as many duplicate lines of code as possible**. Read [Customizing `savename`](@ref) first, as knowledge of that section is used here.
 
 The key ingredient is that [`produce_or_load`](@ref) was made to work well with [`savename`](@ref). You can use this to automate the input-to-output pipeline of your project by following these steps:
-1. Define a custom struct that represents the input configuration for an experiment or a simulation. 
-2. Extend [`savename`](@ref) appropriately for it. 
+1. Define a custom struct that represents the input configuration for an experiment or a simulation.
+2. Extend [`savename`](@ref) appropriately for it.
 3. Define a "main" function that takes as input an instance of this configuration type, and returns the output of the experiment or simulation as dictionary (We're not changing here the "default" way to save files in Julia as `.jld2` files. To save files this way you need your data to be in a dictionary with `String` as keys).
 4. All your input-output scripts are simply put together by first defining the input configuration type, and then calling [`produce_or_load`](@ref) with your pre-defined "main" function (Alternatively, this function can internally call `produce_or_load` and return something else that is of special interest to your specific case).
 
-An example of where this approach is used in the "real world" is e.g. in our paper [Effortless estimation of basins of attraction](https://arxiv.org/abs/2110.04358). Its codebase is here: https://github.com/Datseris/EffortlessBasinsOfAttraction. Don't worry, you need to know nothing about the topic to follow the rest. The point is that we needed to run some kind of simulations for many different dynamical systems, which have different parameters, different dimensionality, etc. But they did have one thing in common: our output was always coming from the same function, `basins_of_attraction`, which allowed using the pipeline we discuss here using [`produce_or_load`](@ref). 
+An example of where this approach is used in the "real world" is e.g. in our paper [Effortless estimation of basins of attraction](https://arxiv.org/abs/2110.04358). Its codebase is here: https://github.com/Datseris/EffortlessBasinsOfAttraction. Don't worry, you need to know nothing about the topic to follow the rest. The point is that we needed to run some kind of simulations for many different dynamical systems, which have different parameters, different dimensionality, etc. But they did have one thing in common: our output was always coming from the same function, `basins_of_attraction`, which allowed using the pipeline we discuss here using [`produce_or_load`](@ref).
 
-So we defined a struct called `BasinConfig` that stored configuration options and system parameters. Then we extended `savename` for it. We defined some function `produce_basins` that takes this configuration file, initializes a dynamical system accordingly, and then makes the output **using `produce_or_load`**. This ensures that we're not running simulations twice if they exist. And keep in mind when you have so many parameters and different possible systems, it is quite easy to unintentionally run the same simulation twice because you "forgot about it". All of this can be found in this file: https://github.com/Datseris/EffortlessBasinsOfAttraction/blob/master/src/produce_basins.jl 
+So we defined a struct called `BasinConfig` that stored configuration options and system parameters. Then we extended `savename` for it. We defined some function `produce_basins` that takes this configuration file, initializes a dynamical system accordingly, and then makes the output **using `produce_or_load`**. This ensures that we're not running simulations twice if they exist. And keep in mind when you have so many parameters and different possible systems, it is quite easy to unintentionally run the same simulation twice because you "forgot about it". All of this can be found in this file: https://github.com/Datseris/EffortlessBasinsOfAttraction/blob/master/src/produce_basins.jl
 
 The benefit? All of our scripts that actually produce what we care about are this short:
 ```julia

--- a/docs/src/workflow.jl
+++ b/docs/src/workflow.jl
@@ -237,6 +237,9 @@ wload(datadir("simulations", firstsim))
 # that called the `@tagsave` command. This information is in the `:script` field of the
 # saved data!
 
+# Lastly, have a look at [`produce_or_load`](@ref) to establish a workflow
+# that helps you run data-producing simulations only once.
+
 # ## 5. Analyze results
 
 # Cool, now we can start analyzing some simulations. The actual analysis is your job,

--- a/docs/src/workflow.jl
+++ b/docs/src/workflow.jl
@@ -134,10 +134,10 @@ params = @strdict a b v method
 # of these parameter containers
 
 allparams = Dict(
-    "a" => [1, 2], # it is inside vector. It is expanded.
-    "b" => [3, 4],
-    "v" => [rand(5)],     # single element inside vector; no expansion
-    "method" => "linear", # not in vector = not expanded, even if naturally iterable
+    "a" => [1, 2],         # it is inside vector. It is expanded.
+    "b" => [3, 4],         # same
+    "v" => [rand(1:2, 2)], # single element inside vector; no expansion
+    "method" => "linear",  # not in vector = not expanded, even if naturally iterable
 )
 
 dicts = dict_list(allparams)
@@ -173,9 +173,10 @@ end
 # *(`wsave` is a function from DrWatson, that ensures that the directory you try to
 # save the data exists. It then calls `FileIO.save`)*
 
-# Here each simulation was named according to a number.
-# But this is not how we do it in science... We typically want the input parameters
-# to be part of the file name. E.g. here we would want the file name to be something like
+# Here each simulation was named according to a somewhat arbitrary integer.
+# Surely we can do better though! We typically want the input parameters
+# to be part of the file name, if the parameters are few and simple, like here.
+# E.g. here we would want the file name to be something like
 # `a=2_b=3_method=linear.jld2`. It would be also nice that such a naming scheme would
 # apply to arbitrary input parameters so that we don't have to manually write
 # `a=$(a)_b=$(b)_method=$(method)` and change this code every time we change
@@ -239,7 +240,8 @@ wload(datadir("simulations", firstsim))
 # saved data!
 
 # Lastly, have a look at [`produce_or_load`](@ref) to establish a workflow
-# that helps you run data-producing simulations only once.
+# that helps you run data-producing simulations only once, saving you both
+# headaches but also precious electricity!
 
 # ## 5. Analyze results
 

--- a/docs/src/workflow.jl
+++ b/docs/src/workflow.jl
@@ -20,7 +20,8 @@
 # So, let's start a new scientific project. You want your project to be contained
 # in a folder. So let's create a new project, located at current working directory
 using DrWatson
-initialize_project("DrWatson Example"; authors="Datseris", force=true)
+## prefer project names without spaces!
+initialize_project("DrWatsonExample"; authors="Datseris", force=true)
 
 # Alright now we have a project set up. The project has a default reasonable structure,
 # as illustrated in the [Default Project Setup](@ref) page:
@@ -58,22 +59,22 @@ Pkg.add(["Statistics", "JLD2"])
 # exist in that file.
 
 # ```@setup workflow
-# cd(joinpath(@__DIR__, "DrWatson Example"))
+# cd(joinpath(@__DIR__, "DrWatsonExample"))
 # ```
 
 
 # Now, with DrWatson every script (typically) starts with the following two lines:
 # ```@setup workflow
-# quickactivate("DrWatson Example", "DrWatson Example")
+# quickactivate("DrWatsonExample", "DrWatsonExample")
 # ```
 
 # ```julia
 # using DrWatson
-# @quickactivate "DrWatson Example" # <- project name
+# @quickactivate "DrWatsonExample" # <- project name
 # ```
 # This command does something simple: it searches the folder of the script, and its
 # parent folders, until it finds a Project.toml. It activates that project, but
-# if the project name doesn't match the given name (here `"DrWatson Example"`)
+# if the project name doesn't match the given name (here `"DrWatsonExample"`)
 # it throws an error. Let's see the project we activated:
 projectname()
 
@@ -292,5 +293,5 @@ safesave(datadir("ana", "linear.jld2"), @strdict analysis)
 
 # Attempt to remove the folder at the end #src
 # ```@setup workflow
-# rm(joinpath(@__DIR__, "DrWatson Example"); force=true, recursive=true)
+# rm(joinpath(@__DIR__, "DrWatsonExample"); force=true, recursive=true)
 # ```

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -9,9 +9,9 @@ convert_to_kw(ex) = error("invalid keyword argument syntax \"$ex\"")
 
 # Misc helpers
 """
-    readenv(var, default::T) where {T}
+    readenv(var, default::T)
 
-Try to read the environment variable `var` and parse it as a `::T`.
+Try to read the environment variable `var` and parse it as type `T`.
 If that fails, return `default`.
 """
 readenv(var, default::T) where {T} = something(tryparse(T, get(ENV, var, "")), Some(default))

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -37,7 +37,7 @@ _wsave(filename, data...; kwargs...) = FileIO.save(filename, data...; kwargs...)
 
 Save `data` at `filename` by first creating the appropriate paths.
 Default fallback is `FileIO.save`. Extend this for your types
-by extending `DrWatson._wsave(filename, data::YourType...; kwargs...)`.
+by extending `DrWatson._wsave(filename, data::YourType, args...; kwargs...)`.
 """
 function wsave(filename, data...; kwargs...)
     mkpath(dirname(filename))
@@ -57,7 +57,7 @@ using Requires
 using Scratch
 const env_var = "DRWATSON_UPDATE_MSG"
 const display_update = true
-const update_version = "2.11.0"
+const update_version = "2.12.0"
 const update_name = "update_v$update_version"
 
 # Get scratch space for this package
@@ -85,15 +85,12 @@ function __init__()
         """
         \nUpdate message: DrWatson v$update_version
 
-        - Now the default project with `initialize_project` will include a documentation
-          and a test folder, as well as scripts to trigger them.
-        - It will also set up CI for both automatically, if a GitHub repo is given.
-        - This new template is showcased in the Good Scientific Code Workshop,
-          see https://youtu.be/x3swaMSCcYk
-        - `@produce_or_load` was broken but because CI was disabled this was
-          silently ignored. `produce_or_load` now has call signature
-          `produce_or_load(f::Function, config, path::String = "")` and
-          same signature for the macro with `path` mandatory.
+        - `produce_or_load` now allows using arbitrary functions when extracting a file
+          name from the input configuration container. Effectively this means that you can
+          use `Base.hash` instead of `savename`, allowing using `produce_or_load` with
+          configuration containers that have too many parameters, or too complicated,
+          to be uniquely mapped to a string via `savename`. A section "`produce_or_load`
+          with hash codes" in Real World Examples highlights this possibility!
 
         To disable future update messages see:
         https://juliadynamics.github.io/DrWatson.jl/dev/#Installing-and-Updating-1

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -185,7 +185,7 @@ function collect_results!(filename, folder;
     if update
         # Delete entries with nonexisting files.
         idx = findall((x)->(!isfile(x.path)), eachrow(df))
-        delete!(df, idx)
+        deleteat!(df, idx)
         verbose && @info "Added $n entries. Updated $u entries. Deleted $(length(idx)) entries."
     else
         verbose && @info "Added $n entries."

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -131,7 +131,9 @@ produce_or_load(path::String, c, f::Function; kwargs...) = produce_or_load(f, c,
 produce_or_load(f::Function, path::String, c; kwargs...) = produce_or_load(f, c, path; kwargs...)
 
 function append_prefix_suffix(name, prefix, suffix)
-    if prefix != ""
+    if isempty(name)
+        name = prefix*'.'*suffix
+    elseif prefix != ""
         name = prefix*'_'*name
     end
     if suffix != ""

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -132,8 +132,13 @@ produce_or_load(f::Function, path::String, c; kwargs...) = produce_or_load(f, c,
 
 function append_prefix_suffix(name, prefix, suffix)
     if isempty(name)
-        name = prefix*'.'*suffix
-    elseif prefix != ""
+        if isempty(suffix)
+            return prefix
+        else
+            return prefix*'.'*suffix
+        end
+    end
+    if prefix != ""
         name = prefix*'_'*name
     end
     if suffix != ""

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -61,7 +61,7 @@ end
   compression).
 """
 function produce_or_load(f::Function, config, path::String = "";
-        suffix = "jld2", prefix = default_prefix(c),
+        suffix = "jld2", prefix = default_prefix(config),
         tag::Bool = readenv("DRWATSON_TAG", istaggable(suffix)),
         gitpath = projectdir(), loadfile = true,
         storepatch::Bool = readenv("DRWATSON_STOREPATCH", false),

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -11,7 +11,7 @@ Here is how it works:
 1. The output data are saved in a file named `name = filename(config)`.
    I.e., the output file's name is created from the configuration container `config`.
    By default, this is `name = `[`savename`](@ref)`(config)`,
-   but can be configured differently, using e.g. `objectid`, see keyword `filename` below.
+   but can be configured differently, using e.g. `hash`, see keyword `filename` below.
    See also [`produce_or_load` with Object IDs](@ref) for an example where part of the
    `config` are functions, which would otherwise be hard to put into `name` with `savename`.
 2. Now, let `file = joinpath(path, prefix*name*'.'*suffix)`.
@@ -38,13 +38,13 @@ end
 * `filename::Union{Function, String} = savename` :
   Configures the `name` of the file to produce or load given the configuration container.
   It may be a one-argument function of `config`, [`savename`](@ref) by default, so that
-  `name = filename(config)`. Useful alternative to `savename` is `objectid`,
+  `name = filename(config)`. Useful alternative to `savename` is `hash`,
   for cases when important options in `config` are difficult
   to transform into a string via [`savename`](@ref). The keyword `filename` could also be
   a `String` directly, possibly extracted from `config` before calling `produce_or_load`,
   in which case `name = filename`.
 * `suffix = "jld2", prefix = default_prefix(config)` : Added to `name`,
-  as `name = prefix*name*'.'*suffix` (i.e., same way it would work in [`savename`](@ref)).
+  as `name = prefix*'_'*name*'.'*suffix` (i.e., like in [`savename`](@ref)).
 
 ### Saving
 * `tag::Bool = DrWatson.readenv("DRWATSON_TAG", istaggable(suffix))` : Save the file
@@ -87,7 +87,7 @@ function produce_or_load(f::Function, config, path::String = "";
     else
         name = string(filename(config))
     end
-    name = prefix*name*'.'*suffix
+    name = prefix*'_'*name*'.'*suffix
     file = joinpath(path, name)
     # Run the remaining logic on whether to produce or load
     if !force && isfile(file)

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -2,8 +2,9 @@ export produce_or_load, @produce_or_load, tagsave, @tagsave, safesave
 
 """
     produce_or_load(f::Function, config, path = "") -> data, file
-The goal of `produce_or_load` is to avoid re-running data-producing code.
-If the output of some function `f` exists on disk, `produce_or_load` will load
+The goal of `produce_or_load` is to avoid running some data-producing code that has
+already been run with a given configuration container `config`.
+If the output of some function `f(config)` exists on disk, `produce_or_load` will load
 it and return it, and if not, it will produce it, save it, and then return it.
 
 Here is how it works:
@@ -21,15 +22,16 @@ Here is how it works:
    that produces your data from the configuration container.
 5. Then save the `data` as `file` and then return `data, file`.
 
-The function `f` should return a dictionary if the data are saved in the default
-format of JLD2.jl., the macro [`@strdict`](@ref) can help with that.
+The function `f` should return a string-keyed dictionary if the data are saved in the
+default format of JLD2.jl., the macro [`@strdict`](@ref) can help with that.
 
 You can use a [do-block]
 (https://docs.julialang.org/en/v1/manual/functions/#Do-Block-Syntax-for-Function-Arguments)
 instead of defining a function to pass in. For example,
 ```julia
 produce_or_load(config, path) do config
-    # simulation using `config` runs here
+    # code using `config` runs here
+    # and then returns a dictionary to be saved
 end
 ```
 

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -87,7 +87,7 @@ function produce_or_load(f::Function, config, path::String = "";
     else
         name = string(filename(config))
     end
-    name = append_prefix_suffix(name)
+    name = append_prefix_suffix(name, prefix, suffix)
     file = joinpath(path, name)
     # Run the remaining logic on whether to produce or load
     if !force && isfile(file)

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -1,7 +1,7 @@
 export produce_or_load, @produce_or_load, tagsave, @tagsave, safesave
 
 """
-    produce_or_load(f::Function, config, path = "") -> data, file
+    produce_or_load(f::Function, config, path = ""; kwargs...) -> data, file
 The goal of `produce_or_load` is to avoid running some data-producing code that has
 already been run with a given configuration container `config`.
 If the output of some function `f(config)` exists on disk, `produce_or_load` will load
@@ -13,9 +13,9 @@ Here is how it works:
    I.e., the output file's name is created from the configuration container `config`.
    By default, this is `name = `[`savename`](@ref)`(config)`,
    but can be configured differently, using e.g. `hash`, see keyword `filename` below.
-   See also [`produce_or_load` with Object IDs](@ref) for an example where part of the
-   `config` are functions, which would otherwise be hard to put into `name` with `savename`.
-2. Now, let `file = joinpath(path, prefix*name*'.'*suffix)`.
+   See also [`produce_or_load` with hash codes](@ref) for an example where `config`
+   would be hard to put into `name` with `savename`, and `hash` is used instead.
+2. Now, let `file = joinpath(path, name)`.
 3. If `file` exists, load it and return
    the contained `data`, along with the global path that it is saved at (`file`).
 4. If the file does not exist then call `data = f(config)`, with `f` your function
@@ -40,10 +40,9 @@ end
 * `filename::Union{Function, String} = savename` :
   Configures the `name` of the file to produce or load given the configuration container.
   It may be a one-argument function of `config`, [`savename`](@ref) by default, so that
-  `name = filename(config)`. Useful alternative to `savename` is `hash`,
-  for cases when important options in `config` are difficult
-  to transform into a string via [`savename`](@ref). The keyword `filename` could also be
-  a `String` directly, possibly extracted from `config` before calling `produce_or_load`,
+  `name = filename(config)`. Useful alternative to `savename` is `hash`.
+  The keyword `filename` could also be a `String` directly,
+  possibly extracted from `config` before calling `produce_or_load`,
   in which case `name = filename`.
 * `suffix = "jld2", prefix = default_prefix(config)` : If not empty, added to `name`
   as `name = prefix*'_'*name*'.'*suffix` (i.e., like in [`savename`](@ref)).

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -43,7 +43,7 @@ end
   to transform into a string via [`savename`](@ref). The keyword `filename` could also be
   a `String` directly, possibly extracted from `config` before calling `produce_or_load`,
   in which case `name = filename`.
-* `suffix = "jld2", prefix = default_prefix(config)` : Added to `name`,
+* `suffix = "jld2", prefix = default_prefix(config)` : If not empty, added to `name`
   as `name = prefix*'_'*name*'.'*suffix` (i.e., like in [`savename`](@ref)).
 
 ### Saving
@@ -87,7 +87,7 @@ function produce_or_load(f::Function, config, path::String = "";
     else
         name = string(filename(config))
     end
-    name = prefix*'_'*name*'.'*suffix
+    name = append_prefix_suffix(name)
     file = joinpath(path, name)
     # Run the remaining logic on whether to produce or load
     if !force && isfile(file)
@@ -128,6 +128,15 @@ produce_or_load(c, f::Function; kwargs...) = produce_or_load(f, c; kwargs...)
 produce_or_load(path::String, c, f::Function; kwargs...) = produce_or_load(f, c, path; kwargs...)
 produce_or_load(f::Function, path::String, c; kwargs...) = produce_or_load(f, c, path; kwargs...)
 
+function append_prefix_suffix(name, prefix, suffix)
+    if prefix != ""
+        name = prefix*'_'*name
+    end
+    if suffix != ""
+        name *= '.'*suffix
+    end
+    return name
+end
 
 """
     @produce_or_load(f, config, path; kwargs...)

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -106,18 +106,18 @@ end
     @test "script" ∈ keys(sim)
     @test "gitcommit" ∈ keys(sim)
     @test sim["script"] |> typeof == String
-    @test endswith(sim["script"], "savefiles_tests.jl#103")
+    @test endswith(sim["script"], "savefiles_tests.jl#102")
     rm(savename(simulation, ending))
     @test !isfile(savename(simulation, ending))
 
     # Test without keywords as well.
-    sim, path = @produce_or_load(f, simulation, "")
+    sim, path = @produce_or_load(f, simulation, ""; suffix = ending)
     @test isfile(savename(simulation, ending))
     rm(savename(simulation, ending))
 
     # Test if tag = false does not interfere with macro script tagging.
     sim, = @produce_or_load(f, simulation, ""; tag = false, suffix = ending)
-    @test endswith(sim["script"], "savefiles_tests.jl#120")
+    @test endswith(sim["script"], "savefiles_tests.jl#119")
     @test "gitcommit" ∉ keys(sim)
     rm(savename(simulation, ending))
 
@@ -157,25 +157,25 @@ end
 @testset "Produce or Load with manual filename ($ending)" for ending ∈ ["bson", "jld2"]
 
     # test with empty `path`
-    filename = joinpath(mktempdir(), "out.$ending")
+    filename = joinpath(mktempdir(), "out")
     @test !isfile(filename)
-    sim, file = @produce_or_load(simulation, filename=filename) do config
+    sim, file = @produce_or_load(simulation; filename=filename, suffix=ending) do config
         f(config)
     end
-    @test file == filename
-    @test isfile(filename)
+    @test file == filename*'.'*ending
+    @test isfile(filename*'.'*ending)
     @test sim["simulation"].T == T
     @test "script" ∈ keys(sim)
-    rm(filename)
+    rm(file)
 
     # test with both `path` and filename
     path = mktempdir()
-    filename = joinpath("sub", "out.$ending")
+    filename = joinpath("sub", "out")
     @test !isfile(joinpath(path, filename))
-    sim, file = @produce_or_load(path, simulation, filename=filename) do config
+    sim, file = @produce_or_load(path, simulation, filename=filename, suffix=ending) do config
         f(config)
     end
-    @test file == joinpath(path, filename)
+    @test file == joinpath(path, filename*'.'*ending)
     @test isfile(file)
     @test sim["simulation"].T == T
     @test "script" ∈ keys(sim)


### PR DESCRIPTION
Alright, so this PR kinda solves my problems I had with really wanting to use `produce_or_load`, but also having too many, or too complicated, simulation parameters. I guess it is a simple inbetween step until DrWatson has some proper way to manage metadata/configuration "files". The discussion here https://github.com/JuliaDynamics/DrWatson.jl/issues/316 and the PR https://github.com/JuliaDynamics/DrWatson.jl/pull/333 are relevant.

My intermediate solution is to allow arbitrary functions in `produce_or_load` that take as an input the `config` container, and return a hopefully unique string for it. In my personal workflow I am using `objectid`, but I haven't tested it extensively to see really how unique or safe its output is. When DrWatsonSim functionality is in, the change in this PR would still allow us to effortlessly integrate DrWatsonSim with `produce_or_load`.

See the new example added in the Real World Usage for an overview of why this functionality is useful: https://juliadynamics.github.io/DrWatson.jl/previews/PR366/real_world/#produce_or_load-with-hash-codes-1 