### PR TITLE
Make default gitignore only ignore folders at the top level

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.12.0"
+version = "2.12.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/defaults/gitignore.txt
+++ b/src/defaults/gitignore.txt
@@ -3,11 +3,11 @@
 ################################################################################
 
 # Folders to ignore - files may be too large, too many, etc. NOTE: EDIT IF NEEDED.
-data
-videos
-plots
-notebooks
-_research
+/data
+/videos
+/plots
+/notebooks
+/_research
 
 ################################################################################
 #                                    Julia                                     #


### PR DESCRIPTION
The current default gitignore ignores all folders and files with names in "Folders to ignore"
This PR suggests only ignoring those names if occurring at the top level. 
