### PR TITLE
fix doc link for update and installing instruction

### DIFF
--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -93,7 +93,7 @@ function __init__()
           with hash codes" in Real World Examples highlights this possibility!
 
         To disable future update messages see:
-        https://juliadynamics.github.io/DrWatson.jl/dev/#Installing-and-Updating-1
+        https://juliadynamics.github.io/DrWatson.jl/v2.12/#Installing-and-Updating-1
         \n
         """; color = :light_magenta)
         touch(joinpath(versions_dir, update_name))


### PR DESCRIPTION
the page doesn't exist on `/dev` any more