### PR TITLE
Fix to Issue#181

### DIFF
--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -29,9 +29,9 @@ function projectdir()
     if is_standard_julia_project()
         @warn "Using the standard Julia project."
     end
-    dirname(rstrip(Base.active_project(), '/'))
+    dirname((Base.active_project()))
 end
-projectdir(args...) = joinpath(projectdir(), args...)
+projectdir(args...) = rstrip(joinpath(projectdir(), args...), '/')
 
 
 # Generate functions to access the path of default subdirectories.

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -29,7 +29,7 @@ function projectdir()
     if is_standard_julia_project()
         @warn "Using the standard Julia project."
     end
-    dirname(Base.active_project())
+    dirname(rstrip(Base.active_project(), '/'))
 end
 projectdir(args...) = joinpath(projectdir(), args...)
 

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -29,7 +29,7 @@ function projectdir()
     if is_standard_julia_project()
         @warn "Using the standard Julia project."
     end
-    dirname((Base.active_project()))
+    dirname(Base.active_project())
 end
 projectdir(args...) = rstrip(joinpath(projectdir(), args...), '/')
 

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -73,7 +73,7 @@ In case this operation fails the values will be treated as `missing`.
 """
 collect_results!(folder; kwargs...) =
 collect_results!(
-joinpath(dirname(folder), "results_$(rstrip(basename(folder)), '/').jld2"),
+joinpath(dirname(rstrip(folder, '/')), "results_$(rstrip(basename(folder)), '/').jld2"),
 folder; kwargs...)
 
 struct InvalidResultsCollection <: Exception

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -73,7 +73,7 @@ In case this operation fails the values will be treated as `missing`.
 """
 collect_results!(folder; kwargs...) =
 collect_results!(
-joinpath(dirname(rstrip(folder, '/')), "results_$(rstrip(basename(folder)), '/').jld2"),
+joinpath(dirname(rstrip(folder, '/')), "results_$(rstrip(basename(folder), '/')).jld2"),
 folder; kwargs...)
 
 struct InvalidResultsCollection <: Exception

--- a/src/result_collection.jl
+++ b/src/result_collection.jl
@@ -73,7 +73,7 @@ In case this operation fails the values will be treated as `missing`.
 """
 collect_results!(folder; kwargs...) =
 collect_results!(
-joinpath(dirname(folder), "results_$(basename(folder)).jld2"),
+joinpath(dirname(folder), "results_$(rstrip(basename(folder)), '/').jld2"),
 folder; kwargs...)
 
 struct InvalidResultsCollection <: Exception

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -75,7 +75,7 @@ finally
     if isfile("results/results_.jld2") == true
         rm("results/results_.jld2")                # In case this test failed, remove the file to not compromise other tests.
     elseif isfile("results_results.jld2")
-        rm("results_results.jld2")                 # If this test passes, remove correct file to not interfer with other tests.
+        rm("results_results.jld2")                 # If this test passes, remove correct file not to interfer with following tests.
     end
 end
 

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -67,7 +67,7 @@ cres_relpath = collect_results!(relpathname, folder;
 ###############################################################################
 #                           Trailing slash in foldername                      #
 ###############################################################################
-#=
+
 df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
 try
     @test !isfile("results/results_.jld2")
@@ -78,7 +78,7 @@ finally
         rm("results_results.jld2")                 # If this test passes, remove correct file to not interfer with other tests.
     end
 end
-=#
+
 ###############################################################################
 #                           Include or exclude files                          #
 ###############################################################################

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -70,12 +70,13 @@ cres_relpath = collect_results!(relpathname, folder;
 
 df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
 try
-    @test !isfile("results/results_.jld2")
+    @test !isfile("results/*_."*ending)
 finally
-    if isfile("results/results_.jld2") == true
-        rm("results/results_.jld2")                # In case this test failed, remove the file to not compromise other tests.
-    elseif isfile("results_results.jld2")
-        rm("results_results.jld2")                 # If this test passes, remove correct file not to interfer with following tests.
+    if isfile("results/*_."*ending) == true
+        rm("results/results_."*ending)                # In case this test failed, remove the file to not compromise other tests.
+    elseif isfile("*_results."*ending)
+        rm("*_results."*ending)                 # If this test passes, remove correct file not to interfer with following tests.
+        rm("result/*_results."*ending)
     end
 end
 

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -68,16 +68,13 @@ cres_relpath = collect_results!(relpathname, folder;
 #                           Trailing slash in foldername                      #
 ###############################################################################
 
-df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
-try
-    @test !isfile("results/*_."*ending)
-finally
-    if isfile("results/*_."*ending) == true
-        rm("results/results_."*ending)                # In case this test failed, remove the file to not compromise other tests.
-    elseif isfile("*_results."*ending)
-        rm("*_results."*ending)                 # If this test passes, remove correct file not to interfer with following tests.
-        rm("result/*_results."*ending)
-    end
+df = collect_results!(datadir("results/"))      # This would produce the incorrect file. (Issue#181)
+
+pathtofile=datadir("results/results_.jld2")     # 
+@test !isfile(pathtofile)
+
+if isfile(pathtofile)
+    rm(pathtofile)                              # In case this test failed, remove the file to not compromise other tests.
 end
 
 ###############################################################################

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -70,7 +70,7 @@ cres_relpath = collect_results!(relpathname, folder;
 
 df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
 try
-    @test !isfile("results/results_.jld2")
+    @test isfile("results/results_.jld2")
 finally
     if isfile("results/results_.jld2") == true
         rm("results/results_.jld2")                # In case this test failed, remove the file to not compromise other tests.

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -70,7 +70,7 @@ cres_relpath = collect_results!(relpathname, folder;
 
 df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
 try
-    @test isfile("results/results_.jld2")
+    @test !isfile("results/results_.jld2")
 finally
     if isfile("results/results_.jld2") == true
         rm("results/results_.jld2")                # In case this test failed, remove the file to not compromise other tests.

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -67,7 +67,7 @@ cres_relpath = collect_results!(relpathname, folder;
 ###############################################################################
 #                           Trailing slash in foldername                      #
 ###############################################################################
-
+#=
 df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
 try
     @test !isfile("results/results_.jld2")
@@ -78,7 +78,7 @@ finally
         rm("results_results.jld2")                 # If this test passes, remove correct file to not interfer with other tests.
     end
 end
-
+=#
 ###############################################################################
 #                           Include or exclude files                          #
 ###############################################################################

--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -65,6 +65,21 @@ cres_relpath = collect_results!(relpathname, folder;
 @info all(startswith.(cres[!,"path"], "data"))
 
 ###############################################################################
+#                           Trailing slash in foldername                      #
+###############################################################################
+
+df = collect_results!(datadir("results/"))         # This would produce the incorrect file. (Issue#181)
+try
+    @test !isfile("results/results_.jld2")
+finally
+    if isfile("results/results_.jld2") == true
+        rm("results/results_.jld2")                # In case this test failed, remove the file to not compromise other tests.
+    elseif isfile("results_results.jld2")
+        rm("results_results.jld2")                 # If this test passes, remove correct file to not interfer with other tests.
+    end
+end
+
+###############################################################################
 #                           Include or exclude files                          #
 ###############################################################################
 


### PR DESCRIPTION
This is my fix #181.
Using the mentioned `rstrip()` for the creation of the default value of `filename` in `result_colletion.jl` the described error will no longer occur.
By also adding `rstrip()` to `projectdir()` function, the error is also fixed if `collect_results!()` is called using defined variables using `datadir()` (as is done in `update_results_tests.jl`).
To demonstrate that, I included a test within `update_resluts_tests.jl` that checks if the bugged file is created.
In the case that the wrongly named and placed file is created, the test will remove it anyways, since it would interfere with the test regarding the dimensions of the dataframes (e.g. ` @test size(cres2) == (6, 7)`).

I hope you will find this helpful!