### PR TITLE
Fix for Issue#251

### DIFF
--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -305,7 +305,7 @@ function initialize_project(path, name = default_name_from_path(path);
             branch = "main"
             if branch != default
                 LibGit2.branch!(repo, branch)
-                LibGit2.delete_branch(GitReference(repo, "refs/heads/$default"))
+                LibGit2.delete_branch(LibGit2.GitReference(repo, "refs/heads/$default"))
             end
         catch err
             @warn "We couldn't rename default branch to `main`, please do it manually. "*


### PR DESCRIPTION
This is my fix #251.

As far as I can tell the problem was that [GitReference()](https://github.com/JuliaDynamics/DrWatson.jl/blob/main/src/project_setup.jl#L308) needed the prefix `LibGit2.`.

This fixes the problem (for me) and the warning message no longer occurs.
The created project only has 1 branch named `main` even if global settings of the user are different. 