### PR TITLE
Force convert of projectdir to String

### DIFF
--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -31,7 +31,7 @@ function projectdir()
     end
     dirname(Base.active_project())
 end
-projectdir(args...) = rstrip(joinpath(projectdir(), args...), '/')
+projectdir(args...) = String(rstrip(joinpath(projectdir(), args...), '/'))
 
 
 # Generate functions to access the path of default subdirectories.

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -30,6 +30,7 @@ end
 @test ispath(joinpath(path, "data", "exp_raw"))
 
 @test ispath(projectdir("data"))
+@test typeof(projectdir("a")) == String
 @test isfile(joinpath(path, ".gitignore"))
 @test uperm(joinpath(path, ".gitignore")) == 0x06
 @test isfile(joinpath(path, "README.md"))
@@ -44,6 +45,7 @@ for dir_type in ("data", "src", "plots", "papers", "scripts")
         @test endswith($fn(joinpath("a", "b")), joinpath($dir_type, joinpath("a", "b")))
         @test endswith($fn("a", "b"), joinpath($dir_type, joinpath("a", "b")))
         @test endswith($fn("a", "b", joinpath("c", "d")), joinpath($dir_type, joinpath("a", "b", "c", "d")))
+        @test typeof($fn("a", "b")) == String
     end
 end
 


### PR DESCRIPTION
Converts output of `projectdir` to String. Added test for all *dir() functions whish is redundant when testing `projectdir()` directly. Happy to remove the extra test if you think it's unnecessary. Fixes #382. 

Passes all tests locally 