### PR TITLE
Removing double prefixes bug in produce_or_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.12.6
+- Crucial bugfix to `produce_or_load`. When used with a prefix, it attached double prefix to the file (one coming as a duplicate from `savename`). This is now fixed, but it means that some files produced with prefix and `produce_or_load` in v2.12 may be re-produced after this update.
+
 # 2.12.0
 - Arbitrary functions extracting strings from data can be used in `produce_or_load` instead of `savename`. `hash` is the most useful function here. An example in Real World Examples highlights this.
 - Additional keywords in `produce_or_load` propagated to `savename` are deprecated.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.12.5"
+version = "2.12.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -79,14 +79,15 @@ function produce_or_load(f::Function, config, path::String = "";
         for the keyword `filename` as `filename = config -> savename(config; kwargs...)`
         """
     end
+    # Prepare absolute file name
     if filename === nothing
         filename = config -> savename(prefix, config, suffix; kwargs...)
-    end
-    # Prepare absolute file name
-    if filename isa AbstractString
+        name = filename(config)
+    elseif filename isa AbstractString
         name = append_prefix_suffix(filename, prefix, suffix)
-    else
+    else #if filename isa Function
         name = string(filename(config))
+        name = append_prefix_suffix(name, prefix, suffix)
     end
     file = joinpath(path, name)
     # Run the remaining logic on whether to produce or load

--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -80,15 +80,14 @@ function produce_or_load(f::Function, config, path::String = "";
         """
     end
     if filename === nothing
-        filename = config -> savename(config; kwargs...)
+        filename = config -> savename(prefix, config, suffix; kwargs...)
     end
     # Prepare absolute file name
     if filename isa AbstractString
-        name = filename
+        name = append_prefix_suffix(filename, prefix, suffix)
     else
         name = string(filename(config))
     end
-    name = append_prefix_suffix(name, prefix, suffix)
     file = joinpath(path, name)
     # Run the remaining logic on whether to produce or load
     if !force && isfile(file)

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -307,6 +307,18 @@ end
     rm(path; recursive = true, force = true)
 end
 
+# Testing proper filenames when default_prefix was modified. See https://github.com/JuliaDynamics/DrWatson.jl/issues/392
+@testset "@produce_or_load with default_prefix modified" begin
+    path = mktempdir()
+
+    DrWatson.default_prefix(ntuple::NamedTuple) = "Prefix_"
+
+    sim, path = produce_or_load(f, simulation, "")
+    @test path == savename(simulation)
+    
+    rm(path)
+    DrWatson.default_prefix(ntuple::NamedTuple) = ""
+end
 
 
 ################################################################################

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -311,10 +311,15 @@ end
 @testset "@produce_or_load with default_prefix modified" begin
     path = mktempdir()
 
-    DrWatson.default_prefix(ntuple::NamedTuple) = "Prefix_"
+    struct Dummy
+        x
+        y
+    end
+    simulation = Dummy(1,2)
+    DrWatson.default_prefix(d::Dummy) = "Prefix_"
 
     sim, path = produce_or_load(f, simulation, "")
-    @test path == savename(simulation)
+    @test path == savename(simulation, "jld2")
     
     rm(path)
     DrWatson.default_prefix(ntuple::NamedTuple) = ""


### PR DESCRIPTION
See #392 

I also created a test, but I was unable to test it locally. Each time I ran tests `BSON` package was uninstalled, and the lack of this package produced errors, and further tests were unable to be run. The issue might be with the system not making a distinction between a system package and a local one. 