### PR TITLE
Fix duplicate prefix for `produce_or_load(; filename)`

### DIFF
--- a/src/saving_files.jl
+++ b/src/saving_files.jl
@@ -137,10 +137,10 @@ function append_prefix_suffix(name, prefix, suffix)
             return prefix*'.'*suffix
         end
     end
-    if prefix != ""
+    if prefix != "" && !startswith(name, prefix)
         name = prefix*'_'*name
     end
-    if suffix != ""
+    if suffix != "" && !endswith(name, suffix)
         name *= '.'*suffix
     end
     return name

--- a/test/savefiles_tests.jl
+++ b/test/savefiles_tests.jl
@@ -315,14 +315,18 @@ end
         x
         y
     end
-    simulation = Dummy(1,2)
-    DrWatson.default_prefix(d::Dummy) = "Prefix_"
 
-    sim, path = produce_or_load(f, simulation, "")
-    @test path == savename(simulation, "jld2")
-    
-    rm(path)
-    DrWatson.default_prefix(ntuple::NamedTuple) = ""
+    simulation = Dummy(1,2)
+    DrWatson.default_prefix(d::Dummy) = "Prefix"
+
+    _, file = produce_or_load(f, simulation, path)
+    @test basename(file) == "Prefix_x=1_y=2.jld2"
+
+    filename = x -> savename(x; connector = " ")
+    _, file = produce_or_load(f, simulation, path; filename)
+    @test basename(file) == "Prefix x=1 y=2.jld2"
+
+    rm(path; recursive = true, force = true)
 end
 
 


### PR DESCRIPTION
Removing [mentioned line](https://github.com/JuliaDynamics/DrWatson.jl/blob/cad2a38cf05002795968fadee39920a516431056/src/saving_files.jl#L90) did not work, as that would break usages like `produce_or_load(; filename=hash, prefix="foo")`. We could make `append_prefix_suffix()` a little more fuzzy, but that would invalidate other cache files.

Let me describe my use case: I just wanted to replace the `savename(; connector)` to have the cache file names a little more readable. According to the documentation, I could simply use `produce_or_load(; kwargs...)` for that purpose. Upon doing so, the warning told me to use the `filename` kwarg instead, which led me to the duplicated prefix described in https://github.com/JuliaDynamics/DrWatson.jl/issues/392#issuecomment-1858309999. Maybe one should set the inner `prefix=""`. What do you think?

Having looked into the code, another issue popped up: should `append_prefix_suffix()` adhere to `savename(; connector)`? Currently, it uses `_` regardless.

Fix #392