### PR TITLE
Adding dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: monthly


### PR DESCRIPTION
## Description

As discussed in https://github.com/JuliaDynamics/DrWatson.jl/pull/407 this PR adds [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to DrWatson.jl to keep the GitHub actions up to date.

## Changes

dependabot.yml added:

  - Update actions monthly