### PR TITLE
implement custom load function for collect_results

### DIFF
--- a/test/update_results_tests.jl
+++ b/test/update_results_tests.jl
@@ -4,265 +4,284 @@ using BSON, DataFrames, FileIO, JLD2
 
 @testset "Collect Results ($ending)" for ending ∈ ["bson", "jld2"]
 
-###############################################################################
-#                        Setup Folder structure                               #
-###############################################################################
-# %%
-cd(@__DIR__)
-isdir("testdir") && rm("testdir", recursive=true)
-mkdir("testdir")
-initialize_project("testdir"; git = false)
-quickactivate("testdir")
+    ###############################################################################
+    #                        Setup Folder structure                               #
+    ###############################################################################
+    # %%
+    cd(@__DIR__)
+    isdir("testdir") && rm("testdir", recursive=true)
+    mkdir("testdir")
+    initialize_project("testdir"; git=false)
+    quickactivate("testdir")
 
-###############################################################################
-#                           Create Dummy Data                                 #
-###############################################################################
-mkdir(datadir("results"))
-cd(datadir("results"))
+    ###############################################################################
+    #                           Create Dummy Data                                 #
+    ###############################################################################
+    mkdir(datadir("results"))
+    cd(datadir("results"))
 
-d = Dict("a" => 1, "b" => "2", "c" => rand(10))
-DrWatson.wsave(savename(d)*"."*ending, d)
+    d = Dict("a" => 1, "b" => "2", "c" => rand(10))
+    DrWatson.wsave(savename(d) * "." * ending, d)
 
-d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
-DrWatson.wsave(savename(d)*"."*ending, d)
+    d = Dict("a" => 3, "b" => "4", "c" => rand(10), "d" => Float64)
+    DrWatson.wsave(savename(d) * "." * ending, d)
 
-d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
-DrWatson.wsave(savename(d)*"."*ending, d)
+    d = Dict("a" => 3, "c" => rand(10), "d" => Float64)
+    DrWatson.wsave(savename(d) * "." * ending, d)
 
-mkdir("subfolder")
-cd("subfolder")
+    mkdir("subfolder")
+    cd("subfolder")
 
-d = Dict("a" => 4., "b" => "twenty" , "d" => Int)
-DrWatson.wsave(savename(d)*"."*ending, d)
+    d = Dict("a" => 4.0, "b" => "twenty", "d" => Int)
+    DrWatson.wsave(savename(d) * "." * ending, d)
 
-###############################################################################
-#                           Collect Data Into DataFrame                       #
-###############################################################################
-using Statistics
-special_list = [ :lv_mean => data -> mean(data["c"]),
-                :lv_var  => data -> var(data["c"])]
+    ###############################################################################
+    #                           Collect Data Into DataFrame                       #
+    ###############################################################################
+    using Statistics
+    special_list = [:lv_mean => data -> mean(data["c"]),
+        :lv_var => data -> var(data["c"])]
 
-black_list = ["c"]
+    black_list = ["c"]
 
-folder = datadir("results")
+    folder = datadir("results")
 
-defaultname = joinpath(dirname(folder), "results_$(basename(folder))."*ending)
-isfile(defaultname) && rm(defaultname)
-cres = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list)
+    defaultname = joinpath(dirname(folder), "results_$(basename(folder))." * ending)
+    isfile(defaultname) && rm(defaultname)
+    cres = collect_results!(defaultname, folder;
+        subfolders=true, special_list=special_list, black_list=black_list)
 
-@test size(cres) == (4, 6)
-for n in ("a", "b", "lv_mean")
-    @test n ∈ String.(names(cres))
-end
-@test "c" ∉ names(cres)
-@test all(startswith.(cres[!,"path"], projectdir()))
+    @test size(cres) == (4, 6)
+    for n in ("a", "b", "lv_mean")
+        @test n ∈ String.(names(cres))
+    end
+    @test "c" ∉ names(cres)
+    @test all(startswith.(cres[!, "path"], projectdir()))
 
-relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder))."*ending)
-cres_relpath = collect_results!(relpathname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list,
-    rpath = projectdir())
-@info all(startswith.(cres[!,"path"], "data"))
+    relpathname = joinpath(dirname(folder), "results_relpath_$(basename(folder))." * ending)
+    cres_relpath = collect_results!(relpathname, folder;
+        subfolders=true, special_list=special_list, black_list=black_list,
+        rpath=projectdir())
+    @info all(startswith.(cres[!, "path"], "data"))
 
-###############################################################################
-#                           Trailing slash in foldername                      #
-###############################################################################
+    struct testDummy
+        a::Float64
+        b::Int64
+        c::Matrix{Float64}
+    end
 
-df = collect_results!(datadir("results/"))      # This would produce the incorrect file. (Issue#181)
+    fname = "dummy.jld2"
+    dummymat = Float64[1 2 3; 0 0 0; 4 5 6]
+    dummy = testDummy(1, 2.0, dummymat)
+    wsave(datadir(fname), "dummy", dummy)
 
-pathtofile=datadir("results/results_.jld2")     # 
-@test !isfile(pathtofile)
+    c = Vector{Union{Missing,Matrix{Float64}}}(undef, 1)
+    c[1] = dummymat
+    expected_result = DataFrame(a=1.0, b=2.0, c=c, path=datadir(fname))
 
-if isfile(pathtofile)
-    rm(pathtofile)                              # In case this test failed, remove the file to not compromise other tests.
-end
+    test_result = collect_results!(datadir(), rinclude=[r"dummy.jld2"], load_function=(filename) -> struct2dict(wload(filename)["dummy"]))
 
-###############################################################################
-#                           Include or exclude files                          #
-###############################################################################
+    @test expected_result == test_result
 
-@test_throws AssertionError collect_results(datadir("results"); rinclude=["a=1"])
+    ###############################################################################
+    #                           Trailing slash in foldername                      #
+    ###############################################################################
 
-df = collect_results(datadir("results"); rinclude=[r"a=1", r"b=3"])
-@test all(row -> row["a"] == 1 || row["b"] == "2", eachrow(df))
+    df = collect_results!(datadir("results/"))      # This would produce the incorrect file. (Issue#181)
 
-df = collect_results(datadir("results"); rexclude=[r"a=3"])
-@test all(df[:,"a"] .!== 3)
+    pathtofile = datadir("results/results_.jld2")     # 
+    @test !isfile(pathtofile)
 
-df = collect_results(datadir("results"); rinclude=[r"a=3"], rexclude=[r"a=3"])
-@test isempty(df)
+    if isfile(pathtofile)
+        rm(pathtofile)                              # In case this test failed, remove the file to not compromise other tests.
+    end
 
-###############################################################################
-#                           Add another file in a sub sub folder              #
-###############################################################################
+    ###############################################################################
+    #                           Include or exclude files                          #
+    ###############################################################################
 
-@test isfile(defaultname)
+    @test_throws AssertionError collect_results(datadir("results"); rinclude=["a=1"])
 
-mkdir("subsubfolder")
-cd("subsubfolder")
-d = Dict("b" => 35., "d" => Number, "c" => rand(5), "e" => "new_column")
-DrWatson.wsave(savename(d)*".bson", d)
-DrWatson.wsave(savename(d)*".jld2", d)
+    df = collect_results(datadir("results"); rinclude=[r"a=1", r"b=3"])
+    @test all(row -> row["a"] == 1 || row["b"] == "2", eachrow(df))
 
-cres2 = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, black_list = black_list)
+    df = collect_results(datadir("results"); rexclude=[r"a=3"])
+    @test all(df[:, "a"] .!== 3)
 
-@test size(cres2) == (6, 7)
-@test all(names(cres) .∈ Ref(names(cres2)))
+    df = collect_results(datadir("results"); rinclude=[r"a=3"], rexclude=[r"a=3"])
+    @test isempty(df)
 
-###############################################################################
-#               Test additional syntax for special list                       #
-###############################################################################
+    ###############################################################################
+    #                           Add another file in a sub sub folder              #
+    ###############################################################################
 
-special_list2 = [ :lv_mean => data -> mean(data["c"]),
-                data -> :lv_var  =>  var(data["c"]),
-                data -> [:lv_mean2 => mean(data["c"]),
-                        :lv_var2  =>  var(data["c"])]]
-black_list = ["c"]
+    @test isfile(defaultname)
 
-folder = datadir("results")
-defaultname2 = joinpath(dirname(folder), "results_betterspeciallist."*ending)
-isfile(defaultname2) && rm(defaultname2)
-cres10 = collect_results!(defaultname2, folder;
-    subfolders = true, special_list=special_list2, black_list = black_list)
+    mkdir("subsubfolder")
+    cd("subsubfolder")
+    d = Dict("b" => 35.0, "d" => Number, "c" => rand(5), "e" => "new_column")
+    DrWatson.wsave(savename(d) * ".bson", d)
+    DrWatson.wsave(savename(d) * ".jld2", d)
 
-@test size(cres10) == (6, 9)
-for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
-    @test n ∈ String.(names(cres10))
-end
-@test "c" ∉ names(cres10)
-###############################################################################
-#                           Load and analyze  DataFrame                       #
-###############################################################################
+    cres2 = collect_results!(defaultname, folder;
+        subfolders=true, special_list=special_list, black_list=black_list)
 
-df = load(defaultname)["df"]
-@test size(df) == size(cres2)
-@test sort(names(df)) == sort(names(cres2))
+    @test size(cres2) == (6, 7)
+    @test all(names(cres) .∈ Ref(names(cres2)))
 
-###############################################################################
-#                            test empty whitelist                             #
-###############################################################################
+    ###############################################################################
+    #               Test additional syntax for special list                       #
+    ###############################################################################
 
-rm(defaultname)
-cres_empty = collect_results!(defaultname, folder;
-    subfolders = true, special_list=special_list, white_list=[])
+    special_list2 = [:lv_mean => data -> mean(data["c"]),
+        data -> :lv_var => var(data["c"]),
+        data -> [:lv_mean2 => mean(data["c"]),
+            :lv_var2 => var(data["c"])]]
+    black_list = ["c"]
 
-@test dropmissing(cres2[!,[:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
+    folder = datadir("results")
+    defaultname2 = joinpath(dirname(folder), "results_betterspeciallist." * ending)
+    isfile(defaultname2) && rm(defaultname2)
+    cres10 = collect_results!(defaultname2, folder;
+        subfolders=true, special_list=special_list2, black_list=black_list)
 
-###############################################################################
-#                           test out-of-place form                            #
-###############################################################################
-cd(@__DIR__)
+    @test size(cres10) == (6, 9)
+    for n in ("a", "b", "lv_mean", "lv_var", "lv_mean2", "lv_var2")
+        @test n ∈ String.(names(cres10))
+    end
+    @test "c" ∉ names(cres10)
+    ###############################################################################
+    #                           Load and analyze  DataFrame                       #
+    ###############################################################################
 
-cres3 = collect_results(folder;
-subfolders = true, special_list=special_list, black_list = black_list)
+    df = load(defaultname)["df"]
+    @test size(df) == size(cres2)
+    @test sort(names(df)) == sort(names(cres2))
 
-@test sort(names(cres3)) == sort(names(cres2))
-@test size(cres3) == size(cres2)
+    ###############################################################################
+    #                            test empty whitelist                             #
+    ###############################################################################
 
-###############################################################################
-#                           test updating feature                             #
-###############################################################################
+    rm(defaultname)
+    cres_empty = collect_results!(defaultname, folder;
+        subfolders=true, special_list=special_list, white_list=[])
 
-@testset "Test updating feature $(mtime_info)" for mtime_info in ["with mtime", "without initial update", "without mtime", "with corrupt mtime"]
-    # Create a temp directory and run the tests, creating files in that folder
-    # Julia takes care of removing the folder after the function is done.
-    mktempdir(datadir()) do folder
-        # Create three data files with slightly different data
-        d = Dict("idx" => :keep, "b" => "some_value")
-        fname_keep = joinpath(folder, savename(d, ending, ignores = ("b",)))
-        DrWatson.wsave(fname_keep, d)
+    @test dropmissing(cres2[!, [:lv_mean, :lv_var, :path]]) == dropmissing(cres_empty)
 
-        d = Dict("idx" => :delete, "b" => "some_other_value")
-        fname_delete = joinpath(folder, savename(d, ending, ignores = ("b",)))
-        DrWatson.wsave(fname_delete, d)
+    ###############################################################################
+    #                           test out-of-place form                            #
+    ###############################################################################
+    cd(@__DIR__)
 
-        d = Dict("idx" => :to_modify, "b" => "original_value")
-        fname_modify = joinpath(folder, savename(d, ending, ignores = ("b",)))
-        DrWatson.wsave(fname_modify, d)
+    cres3 = collect_results(folder;
+        subfolders=true, special_list=special_list, black_list=black_list)
 
-        # Collect our "results"
-        if mtime_info == "without initial update"
-            # Test this case: https://github.com/JuliaDynamics/DrWatson.jl/pull/286#pullrequestreview-755999610
-            cres_before = collect_results!(folder; update = false)
-        else
-            cres_before = collect_results!(folder; update = true)
-        end
+    @test sort(names(cres3)) == sort(names(cres2))
+    @test size(cres3) == size(cres2)
 
-        if mtime_info == "without mtime"
-            # Leave out the mtime information to simulate old results collection.
-            wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before))
-        elseif mtime_info == "with corrupt mtime"
-            # Corrupt mtime information
-            wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before, "mtime" => Dict{String,Float64}()))
-        else
-            # Modify one data file
-            d = Dict("idx" => :to_modify, "b" => "modified_value")
+    ###############################################################################
+    #                           test updating feature                             #
+    ###############################################################################
+
+    @testset "Test updating feature $(mtime_info)" for mtime_info in ["with mtime", "without initial update", "without mtime", "with corrupt mtime"]
+        # Create a temp directory and run the tests, creating files in that folder
+        # Julia takes care of removing the folder after the function is done.
+        mktempdir(datadir()) do folder
+            # Create three data files with slightly different data
+            d = Dict("idx" => :keep, "b" => "some_value")
+            fname_keep = joinpath(folder, savename(d, ending, ignores=("b",)))
+            DrWatson.wsave(fname_keep, d)
+
+            d = Dict("idx" => :delete, "b" => "some_other_value")
+            fname_delete = joinpath(folder, savename(d, ending, ignores=("b",)))
+            DrWatson.wsave(fname_delete, d)
+
+            d = Dict("idx" => :to_modify, "b" => "original_value")
+            fname_modify = joinpath(folder, savename(d, ending, ignores=("b",)))
             DrWatson.wsave(fname_modify, d)
 
-            # Delete another data file
-            rm(fname_delete)
-        end
+            # Collect our "results"
+            if mtime_info == "without initial update"
+                # Test this case: https://github.com/JuliaDynamics/DrWatson.jl/pull/286#pullrequestreview-755999610
+                cres_before = collect_results!(folder; update=false)
+            else
+                cres_before = collect_results!(folder; update=true)
+            end
 
-        # Collect the "results" again
-        if (mtime_info == "without mtime") || (mtime_info == "with corrupt mtime") 
-            @test_throws DrWatson.InvalidResultsCollection collect_results!(folder; update = true)
+            if mtime_info == "without mtime"
+                # Leave out the mtime information to simulate old results collection.
+                wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before))
+            elseif mtime_info == "with corrupt mtime"
+                # Corrupt mtime information
+                wsave(joinpath(dirname(folder), "results_$(basename(folder)).jld2"), Dict("df" => cres_before, "mtime" => Dict{String,Float64}()))
+            else
+                # Modify one data file
+                d = Dict("idx" => :to_modify, "b" => "modified_value")
+                DrWatson.wsave(fname_modify, d)
+
+                # Delete another data file
+                rm(fname_delete)
+            end
+
+            # Collect the "results" again
+            if (mtime_info == "without mtime") || (mtime_info == "with corrupt mtime")
+                @test_throws DrWatson.InvalidResultsCollection collect_results!(folder; update=true)
+            else
+                cres_after = collect_results!(folder; update=true)
+
+                # Compare the before and after - they should differ
+                @test cres_before[:, [:idx, :b]] != cres_after[:, [:idx, :b]]
+                # The unmodified entry should be the same
+                @test ((:keep ∈ cres_before.idx) && (:keep ∈ cres_after.idx))
+                # The deleted entry should be gone
+                @test ((:delete ∈ cres_before.idx) && (:delete ∉ cres_after.idx))
+                # The modified entry should differ between before and after
+                @test cres_before.b[cres_before.idx.==:to_modify][1] == "original_value"
+                @test cres_after.b[cres_after.idx.==:to_modify][1] == "modified_value"
+            end
+        end
+    end
+
+    ###############################################################################
+    #                           test jldopen                                      #
+    ###############################################################################
+
+    mktempdir(datadir()) do folder
+        # Create a data file
+        d = Dict("idx" => 1, "value" => rand(100000))
+        fname = joinpath(folder, savename(d, ending, ignores=("value",)))
+        DrWatson.wsave(fname, d)
+
+        if ending == "jld2"
+            msg_re = r"Opening .* with jldopen."
         else
-            cres_after = collect_results!(folder; update = true)
-
-            # Compare the before and after - they should differ
-            @test cres_before[:,[:idx, :b]] != cres_after[:,[:idx, :b]]
-            # The unmodified entry should be the same
-            @test ((:keep ∈ cres_before.idx) && (:keep ∈ cres_after.idx))
-            # The deleted entry should be gone
-            @test ((:delete ∈ cres_before.idx) && (:delete ∉ cres_after.idx))
-            # The modified entry should differ between before and after
-            @test cres_before.b[cres_before.idx .== :to_modify][1] == "original_value"
-            @test cres_after.b[cres_after.idx .== :to_modify][1] == "modified_value"
+            msg_re = r"Opening .* with fallback wload."
         end
+        @test_logs (:debug, msg_re) min_level = Base.CoreLogging.Debug match_mode = :any cres = collect_results(folder, black_list=("value",))
+
+        @test cres.idx[1] == 1 # It's what we've saved above.
+        @test size(cres, 1) == 1 # only one file
+        @test size(cres, 2) == 2 # idx and path
     end
-end
 
-###############################################################################
-#                           test jldopen                                      #
-###############################################################################
+    ###############################################################################
+    #                              Quickactivate macro                            #
+    ###############################################################################
 
-mktempdir(datadir()) do folder
-    # Create a data file
-    d = Dict("idx" => 1, "value" => rand(100000))
-    fname = joinpath(folder, savename(d, ending, ignores = ("value",)))
-    DrWatson.wsave(fname, d)
-
-    if ending == "jld2"
-        msg_re = r"Opening .* with jldopen."
-    else
-        msg_re = r"Opening .* with fallback wload."
+    cd(@__DIR__)
+    isdir("testdir") && rm("testdir", recursive=true)
+    initialize_project("testdir"; git=false)
+    open(joinpath("testdir", "testinclude.jl"), "w") do f
+        write(f, "@quickactivate\n")
     end
-    @test_logs (:debug, msg_re) min_level=Base.CoreLogging.Debug match_mode=:any cres = collect_results(folder, black_list = ("value",))
+    include(joinpath("testdir", "testinclude.jl"))
+    @test Base.active_project() == abspath(joinpath("testdir", "Project.toml"))
 
-    @test cres.idx[1] == 1 # It's what we've saved above.
-    @test size(cres,1) == 1 # only one file
-    @test size(cres,2) == 2 # idx and path
-end
+    ###############################################################################
+    #                                 Delete Folders                              #
+    ###############################################################################
 
-###############################################################################
-#                              Quickactivate macro                            #
-###############################################################################
-
-cd(@__DIR__)
-isdir("testdir") && rm("testdir", recursive=true)
-initialize_project("testdir"; git = false)
-open(joinpath("testdir","testinclude.jl"),"w") do f
-    write(f,"@quickactivate\n")
-end
-include(joinpath("testdir", "testinclude.jl"))
-@test Base.active_project() == abspath(joinpath("testdir","Project.toml"))
-
-###############################################################################
-#                                 Delete Folders                              #
-###############################################################################
-
-cd(@__DIR__)
-rm("testdir", recursive=true)
+    cd(@__DIR__)
+    rm("testdir", recursive=true)
 
 end


### PR DESCRIPTION
Here is my first pass at implementing #420

This adds an optional wrapper around the loading of data when being processed by `collect_results`. This is useful in case the data being loaded from file needs to be modified before being processed by `collect_results`. The wrapper can be passed to `collect_results` using the new kwarg `load_function_wrapper`.

For example, consider you have a simulation result that is saved to disc as a struct. When loaded from disc it will be as a one-element dict containing that struct. The struct may contain many fields that should form the columns of the DataFrame. In that case you'd want to convert the struct to a dictionary after being loaded but before being processed by `collect_results`. The `load_function_wrapper` provides such a possibility.

By default `load_function_wrapper=nothing` and the default methods will be used to load data (so `wload` and `jld2.jldopen`).

Here is an example usage.

```julia
struct Dummy
    a::Float64
    b::Int64
    c::Matrix{Float64}
end

dummy = Dummy(1.0, 1, rand(3,3))
wsave("dummy.jld2", "dummy", dummy)

tmp = wload("dummy.jld2") # one-element Dict with key "dummy" that contains the struct Dummy(1.0, 1, rand(3,3))

tmp["dummy"] # now the struct itself instead of a dictionary
struct2dict(tmp["dummy"]) # Now a dict where the fields of the structs are now the keys of the dict

# To get desired behavior when calling collect_results we do the following
tabulated_results = collect_results("./", load_function_wrapper = (d) -> struct2dict(d["dummy"]))
```

All 587 tests passed. 

I did try to implement something along the lines of the following.

```julia
function collect_results!(filename, folder;
    valid_filetypes=[".bson", "jld", ".jld2"],
    subfolders=false,
    rpath=nothing,
    verbose=true,
    update=false,
    newfile=false, # keyword only for defining collect_results without !
    rinclude=[r""],
    rexclude=[r"^\b$"],
    load_function_wrapper=(args...; kwargs...) -> wload(args...; kwargs...),
    kwargs...)
```
But I had difficulties getting this to work with `to_data_row` for the specialized JLD2 case. In that case it doesn't expect `wload` (as far as I could tell, I'm not an expert on JLD2 though) so that as a default doesn't work. But I am happy to refactor this PR if there is a better or more idiomatic way to achieve this. 