### PR TITLE
Avoid deadlock when reading stdout and stderr from commands

### DIFF
--- a/src/saving_tools.jl
+++ b/src/saving_tools.jl
@@ -109,6 +109,8 @@ Return a `NamedTuple` with the fields `exception`, `out` and `err`.
 function read_stdout_stderr(cmd::Cmd)
     out = Pipe()
     err = Pipe()
+    out_string = @async read(out, String)
+    err_string = @async read(err, String)
     exception = nothing
     try
         run(pipeline(cmd,stderr=err, stdout=out), wait=true)
@@ -117,7 +119,7 @@ function read_stdout_stderr(cmd::Cmd)
     end
     close(out.in)
     close(err.in)
-    return (exception = exception, out=read(out,String), err=read(err,String))
+    return (exception = exception, out = fetch(out_string), err = fetch(err_string))
 end
 
 """


### PR DESCRIPTION
The `gitpatch` function sometimes hangs for large git diffs. This seems to be happening because the `read_stdout_stderr` function is writing to the `out` and `err` pipes, but no task is reading from them, so they fill up, and the process locks up waiting to write more data.

This change spawns separate tasks to read from the `out` and `err` pipes, thus avoiding the deadlock.

The Julia compat for this package is set to 1.0, so I opted to use `@async` instead of `Threads.@spawn`.

Fixes #300