### PR TITLE
Add `SubString` to `default_allowed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.19.0
+
+- Add `SubString` to `default_allowed` so that `savename(prefix, (; a=a),
+  suffix)` works as expected if `a` was produced by `String` operations such as
+  `split`.
+
 # 2.18.0
 
 - `tag!` and parent functions allow keyword `warn`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.18.0"
+version = "2.19.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/naming.jl
+++ b/src/naming.jl
@@ -41,7 +41,7 @@ See also [`parse_savename`](@ref) and [`@savename`](@ref).
 ## Customization keywords
 * `allowedtypes = default_allowed(c)` : Only values of type subtyping
   anything in `allowedtypes` are used in the name. By default
-  this is `(Real, String, Symbol, TimeType)`.
+  this is `(Real, String, SubString, Symbol, TimeType)`.
 * `accesses = allaccess(c)` : specify which specific keys you want
   to use with the keyword `accesses`. By default this is all possible
   keys `c` can be accessed with, see [`allaccess`](@ref).
@@ -195,10 +195,10 @@ Return all the keys `c` that will be ignored in [`savename`](@ref).
 allignore(c::Any) = ()
 
 """
-    default_allowed(c) = (Real, String, Symbol, TimeType)
+    default_allowed(c) = (Real, String, SubString, Symbol, TimeType)
 Return the (super-)Types that will be used as `allowedtypes` in [`savename`](@ref).
 """
-default_allowed(c) = (Real, String, Symbol, TimeType)
+default_allowed(c) = (Real, String, SubString, Symbol, TimeType)
 
 """
     default_prefix(c) = ""


### PR DESCRIPTION
Fixes #436.

I kept the change set small; it would have been possible to also adjust the examples (in particular, [the real world example](https://github.com/JuliaDynamics/DrWatson.jl/blob/main/docs/src/real_world.md)), but since those did not use the most up-to-date definition of `default_allowed` anyway, I abstained from doing so.