### PR TITLE
Plots.jl extension for `wsave`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
+[weakdeps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[extensions]
+PlotsExt = "Plots"
+
 [compat]
 FileIO = "1.0.6"
 JLD2 = "0.4.15, 0.5, 0.6"

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -1,0 +1,13 @@
+module PlotsExt
+
+using DrWatson
+using Plots
+
+function DrWatson._wsave(filename, p::AbstractPlot, args...; kwargs...)
+    isempty(args) || @warn "Saving a `Plots.Plot` does not support additional `args...`; ignoring `args = $args`"
+    isempty(kwargs) || @warn "Saving a `Plots.Plot` does not support `kwargs...`; ignoring `kwargs = $(NamedTuple(kwargs))`"
+
+    savefig(p, filename)
+end
+
+end


### PR DESCRIPTION
Almost all scientific projects generate plots; many use `Plots.jl`.
To use the saving tools of `DrWatson` together with the [savefig](https://docs.juliaplots.org/latest/output/) function of  `Plots.jl`, one has to manually add the method
```Julia
DrWatson._wsave(filename, p::AbstractPlot, args...; kwargs...) = savefig(p, filename)
```
This PR adds a [package extension](https://docs.julialang.org/en/v1/manual/code-loading/#man-extensions) that does this automatically when `using Plots`.

The `savefig` function is preferable for `Plots.Plot` compared to the current default `FileIO.save` because it supports (depending on the backend) more file types.
Users can still overwrite `_wsave(filename, p::AbstractPlot)` if they want different behavior.

In the implementation I propose, the `args...` and `kwargs...` are ignored. We could also let it error instead, let me know what you prefer.