### PR TITLE
Directory handling with multiple `Project.toml` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.20.0
+
+- Refactor `projectdir` and `projectname` functions to handle projects with a main `Project.toml` file and sub-`Project.toml` files.
+- Add warnings to `projectdir`, `projectname` and `quickactivate` when a sub-project is active or activated.
+
 # 2.19.0
 
 - Add `SubString` to `default_allowed` so that `savename(prefix, (; a=a),

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DrWatson"
 uuid = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 repo = "https://github.com/JuliaDynamics/DrWatson.jl.git"
-version = "2.19.1"
+version = "2.20.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -14,6 +14,30 @@ function is_standard_julia_project()
     Base.active_project() == Base.load_path_expand("@v#.#")
 end
 
+"""
+    projecttomldir()
+
+Return the directory of the Project.toml file of the currently active project.
+"""
+projecttomldir() = dirname(Base.active_project())
+
+"""
+    manifesttomldir()
+
+Return the directory of the Manifest.toml file of the currently active project.
+"""
+function manifesttomldir()
+    proj = Base.active_project()
+    manif = Pkg.Types.EnvCache(proj).manifest_file
+    return dirname(manif)
+end
+
+"""
+    is_sub_project()
+
+Return `true` if the currently active project is a sub-project.
+"""
+is_sub_project() = projecttomldir() != manifesttomldir()
 
 """
     projectdir()
@@ -29,7 +53,12 @@ function projectdir()
     if is_standard_julia_project()
         @warn "Using the standard Julia project."
     end
-    dirname(Base.active_project())
+    
+    if is_sub_project()
+        @warn "Using a sub-project."
+    end
+
+    return manifesttomldir()
 end
 projectdir(args...) = joinpath(projectdir(), args...)
 
@@ -46,11 +75,20 @@ end
     projectname()
 Return the name of the currently active project.
 """
-projectname() = _projectname(try
-                                Pkg.Types.read_project(Base.active_project())
-                             catch
-                                nothing
-                             end)
+unction projectname()
+    pkg = try
+        root_proj = joinpath(manifesttomldir(), "Project.toml")
+        Pkg.Types.read_project(root_proj)
+    catch
+        return nothing
+    end
+
+    if is_sub_project()
+        @warn "The active project is a sub-project of $(_projectname(pkg))."
+    end
+
+    return _projectname(pkg)
+end
 _projectname(pkg) = pkg.name
 # Pkg in julia 1.0 returns a dict
 _projectname(pkg::Dict) = pkg["name"]
@@ -139,6 +177,11 @@ function quickactivate(path, name = nothing)
         "The activated project did not match asserted name. Current project "*
         "name is $(projectname()) while the asserted name is $name."
         )
+    end
+    if is_sub_project()
+        root_proj = joinpath(manifesttomldir(), "Project.toml")
+        pkg = Pkg.Types.read_project(root_proj)
+        @warn "Activated a sub-project of $(_projectname(pkg))." # use _projectname to avoid double warnings
     end
     return nothing
 end

--- a/src/project_setup.jl
+++ b/src/project_setup.jl
@@ -75,7 +75,7 @@ end
     projectname()
 Return the name of the currently active project.
 """
-unction projectname()
+function projectname()
     pkg = try
         root_proj = joinpath(manifesttomldir(), "Project.toml")
         Pkg.Types.read_project(root_proj)

--- a/test/project_tests.jl
+++ b/test/project_tests.jl
@@ -84,6 +84,26 @@ cd(path)
 @test findproject(pwd()) == pwd()
 cd()
 
+# Test project with a module and workspaces
+path = "test_project"
+name = "ProjectPackage"
+initialize_project(path, name; force=true)
+
+open(joinpath(path, "Project.toml"), "a") do io # add workspace
+    println(io, "[workspace]")
+    println(io, "projects = [\"test\"]")
+end
+open(joinpath(path, "src", name * ".jl"), "w") do io # add module
+    println(io, "module $name")
+    println(io, "")
+    println(io, "end")
+end
+Pkg.activate(joinpath(path, "test")) # activate and add an example dependency
+Pkg.add("Test")
+
+@test projectname() == name
+@test endswith(projectdir(), path)
+
 # Test templates
 t1 = ["data", "documents" => ["a", "b"]]
 initialize_project(path, name; force=true, git=false, template=t1)


### PR DESCRIPTION
This fixes Issue #443.

## General purpose
For instance, if you have the following project structure:
```
│projectdir          
│
├── scripts          
│   └── Project.toml     <- Packages used for plotting but not used in the main Project.toml
│
├── src              <- Source code 
├── Project.toml     <- Main project file
└── Manifest.toml
```

In the current version, if the active project is `projectdir/scripts` then the function `projectdir` (and in turn all the `xxxdir`) are relative to `projectdir/scripts`. 
This PR makes them relative to `projectdir` instead. It assumes that the "sub-project" `projectdir/scripts` is a [workspace or a target](https://pkgdocs.julialang.org/v1/creating-packages/#Test-specific-dependencies) of the main project.

## Implementation
- Main modifications are in the `projectdir` and `projectname` functions.
- Warnings are added to `projectdir`, `projectname` and `quickactivate` when a sub-project (e.g.  `projectdir/scripts` in the example above) is active or activated.
- Unit test for `projectdir` and `projectname` in this multiple project setting.