### PR TITLE
Fix savename expand with nested structs

### DIFF
--- a/src/naming.jl
+++ b/src/naming.jl
@@ -116,7 +116,8 @@ function savename(prefix::String, c, suffix::String;
         t = typeof(val)
         if any(x -> (t <: x), allowedtypes)
             if label ∈ expand
-                isempty(val) && continue
+                # the catch block handles types that do not implement `isempty` (e.g., user defined types)
+                (try isempty(val) catch; false end) && continue
                 sname = savename(val; connector=",", digits=digits, sigdigits=sigdigits, equals = equals)
                 isempty(sname) && continue
                 entry = label*equals*'('*sname*')'

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -132,6 +132,31 @@ let
 end
 
 
+@testset "savename nested structs" begin
+    struct X
+        x1::Int
+        x2::String
+    end
+
+    struct Y
+        y1::Int
+    end
+
+    struct Z
+        x::X
+        y::Y
+    end
+
+    DrWatson.default_allowed(::Z) = (X, Y)
+    DrWatson.default_expand(::Z) = ["x", "y"]
+
+    x = X(1, "abc")
+    y = Y(4)
+    z = Z(x, y)
+    @test savename(z) == "x=(x1=1,x2=abc)_y=(y1=4)"
+end
+
+
 # Dedicated Macro tests
 @testset "Macro Tests" begin
     x = 3; y = 5.0; z = 42;


### PR DESCRIPTION
Fixes crash of `savename` when expanding on types that don't implement `isempty`. 
Closes #215.